### PR TITLE
PyMODM-27 - Allow index options to be specified in Meta inner class.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,8 @@ Here's a basic example of how to define some models and connect them to MongoDB:
 
 .. code-block:: python
 
+  from pymongo import TEXT
+  from pymongo.operations import IndexModel
   from pymodm import connect, fields, MongoModel, EmbeddedMongoModel
 
 
@@ -105,6 +107,9 @@ Here's a basic example of how to define some models and connect them to MongoDB:
       # database.
       comments = fields.EmbeddedDocumentListField('Comment')
 
+      class Meta:
+          # Text index on content can be used for text search.
+          indexes = [IndexModel([('content', TEXT)])]
 
   # This is an "embedded" model and will be stored as a sub-document.
   class Comment(EmbeddedMongoModel):

--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -28,8 +28,8 @@ class MongoBaseField(object):
     empty_values = [[], (), {}, None, '', b'', set()]
 
     def __init__(self, verbose_name=None, mongo_name=None, primary_key=False,
-                 unique=False, blank=False, required=False,
-                 default=None, choices=None, validators=None):
+                 blank=False, required=False, default=None, choices=None,
+                 validators=None):
         """Create a new Field instance.
 
         :parameters:
@@ -38,8 +38,6 @@ class MongoBaseField(object):
           - `primary_key`: If ``True``, this Field will be used for the ``_id``
             field when stored in MongoDB. Note that the `mongo_name` of the
             primary key field cannot be changed from ``_id``.
-          - `unique`: If ``True``, ensure that there is an index that enforces
-            uniqueness on this Field's value.
           - `blank`: If ``True``, allow this field to have an empty value.
           - `required`: If ``True``, do not allow this field to be unspecified.
           - `default`: The default value to use for this field if no other value
@@ -54,15 +52,14 @@ class MongoBaseField(object):
             'verbose_name', verbose_name)
         self.mongo_name = validate_string_or_none('mongo_name', mongo_name)
         self.primary_key = validate_boolean('primary_key', primary_key)
-        # "attname" is the attribute name of this field on the Model.
-        # We may be assigned a different name by the Model's metaclass later on.
-        self.unique = validate_boolean('unique', unique)
         self.blank = validate_boolean('blank', blank)
         self.required = validate_boolean('required', required)
         self.choices = validate_list_tuple_or_none('choices', choices)
         self.validators = validate_list_tuple_or_none(
             'validators', validators or [])
         self.default = default
+        # "attname" is the attribute name of this field on the Model.
+        # We may be assigned a different name by the Model's metaclass later on.
         self.attname = mongo_name
         if self.primary_key and self.mongo_name not in (None, '_id'):
             raise ValueError(

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -158,6 +158,11 @@ class TopLevelMongoModelMetaclass(MongoModelMetaclass):
             new_class.add_to_class('objects', manager)
         new_class._default_manager = manager
 
+        # Create any indexes defined in our options.
+        indexes = new_class._mongometa.indexes
+        if indexes:
+            new_class._mongometa.collection.create_indexes(indexes)
+
         return new_class
 
     def _find_manager(cls):
@@ -421,6 +426,9 @@ class MongoModel(with_metaclass(TopLevelMongoModelMetaclass, MongoModelBase)):
         when reading documents.
       - `write_concern`: The :class:`~pymongo.write_concern.WriteConcern` to use
         for write operations.
+      - `indexes`: This is a list of :class:`~pymongo.operations.IndexModel`
+        instances that describe the indexes that should be created for this
+        model. Indexes are created when the class definition is evaluated.
 
     .. note:: Creating an instance of MongoModel does not create a document in
               the database.

--- a/pymodm/base/options.py
+++ b/pymodm/base/options.py
@@ -22,7 +22,8 @@ from pymodm.fields import EmbeddedDocumentField, EmbeddedDocumentListField
 # Attributes that can be user-specified in MongoOptions.
 DEFAULT_NAMES = (
     'connection_alias', 'collection_name', 'codec_options', 'final',
-    'cascade', 'read_preference', 'read_concern', 'write_concern')
+    'cascade', 'read_preference', 'read_concern', 'write_concern',
+    'indexes')
 
 
 class MongoOptions(object):
@@ -46,6 +47,7 @@ class MongoOptions(object):
         self.read_preference = None
         self.read_concern = None
         self.write_concern = None
+        self.indexes = []
         self._auto_dereference = True
 
     @property

--- a/test/test_model_inheritance.py
+++ b/test/test_model_inheritance.py
@@ -14,6 +14,8 @@
 
 from bson import SON
 
+from pymongo.operations import IndexModel
+
 from pymodm import fields, MongoModel
 from pymodm.errors import InvalidModel
 
@@ -88,3 +90,20 @@ class ModelInheritanceTest(ODMTestCase):
     def test_final_metadata_storage(self):
         FinalModel().save()
         self.assertNotIn('_cls', DB.final_model.find_one())
+
+    def test_indexes(self):
+        class ModelWithIndexes(MongoModel):
+            product_id = fields.UUIDField()
+            name = fields.CharField()
+
+            class Meta:
+                indexes = [
+                    IndexModel([('product_id', 1), ('name', 1)], unique=True)
+                ]
+
+        # No Exception.
+        class ChildModel(ModelWithIndexes):
+            pass
+
+        index_info = DB.model_with_indexes.index_information()
+        self.assertTrue(index_info['product_id_1_name_1']['unique'])


### PR DESCRIPTION
reviewers: @shaneharvey @behackett @rozza

https://jira.mongodb.org/browse/PYMODM-27

I'm switching over to reviews on Github, since we can easily see test output/syntax highlighting/manage "patch sets" much more easily.

This removes the `unique` argument from Field constructors in favor of having indexes defined in the `Meta` inner class. This way, we don't have to change the Field API every time we change something about MongoDB indexes, since it's all encapsulated in PyMongo's IndexModel. This also makes it a lot easier to say "this field should be unique with this other field". This library is still in alpha, so I'm not worried about breaking API at this stage.

Example:

```python
class Order(MongoModel):
  product_id = fields.UUIDField()
  name = fields.CharField()

  class Meta:
    indexes = [
      IndexModel([('product_id', ASCENDING), ('name', ASCENDING)], unique=True)
    ]
```