### PR TITLE
PyMODM-25 - Make Field types available from 'pymodm' module.

### DIFF
--- a/pymodm/__init__.py
+++ b/pymodm/__init__.py
@@ -14,6 +14,10 @@
 
 from pymodm.base import MongoModel, EmbeddedMongoModel
 from pymodm.connection import connect
+from pymodm.fields import *
 
+from pymodm import base, connection, fields
+
+__all__ = fields.__all__ + connection.__all__ + base.__all__
 
 version = '0.2.dev0'

--- a/pymodm/base/__init__.py
+++ b/pymodm/base/__init__.py
@@ -13,3 +13,7 @@
 # limitations under the License.
 
 from pymodm.base.models import MongoModel, EmbeddedMongoModel
+
+from pymodm.base import models
+
+__all__ = models.__all__

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -28,6 +28,9 @@ from pymodm.fields import ObjectIdField
 from pymodm.manager import Manager
 
 
+__all__ = ['MongoModel', 'EmbeddedMongoModel']
+
+
 class MongoModelMetaclass(type):
     """Base metaclass for all Models."""
 

--- a/pymodm/connection.py
+++ b/pymodm/connection.py
@@ -22,6 +22,9 @@ from pymongo import uri_parser, MongoClient
 from pymodm.compat import reraise
 
 
+__all__ = ['connect']
+
+
 """Information stored with each connection alias."""
 ConnectionInfo = namedtuple(
     'ConnectionInfo', ('parsed_uri', 'conn_string', 'database'))

--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -48,7 +48,7 @@ except ImportError:
 
 
 from pymodm import validators
-from pymodm.base.fields import RelatedModelFieldsBase
+from pymodm.base.fields import RelatedModelFieldsBase, GeoJSONField
 from pymodm.common import _import
 from pymodm.compat import text_type, string_types, PY3
 from pymodm.connection import _get_db
@@ -56,6 +56,19 @@ from pymodm.errors import ValidationError, ConfigurationError
 from pymodm.base.fields import MongoBaseField
 from pymodm.files import File, GridFSStorage, FieldFile, ImageFieldFile
 from pymodm.vendor import parse_datetime
+
+
+__all__ = [
+    'CharField', 'IntegerField', 'BigIntegerField', 'ObjectIdField',
+    'BinaryField', 'BooleanField', 'DateTimeField', 'Decimal128Field',
+    'EmailField', 'FileField', 'ImageField', 'FloatField',
+    'GenericIPAddressField', 'URLField', 'UUIDField',
+    'RegularExpressionField', 'JavaScriptField', 'TimestampField',
+    'DictField', 'OrderedDictField', 'ListField', 'PointField',
+    'LineStringField', 'PolygonField', 'MultiPointField',
+    'MultiLineStringField', 'MultiPolygonField', 'GeometryCollectionField',
+    'EmbeddedDocumentField', 'EmbeddedDocumentListField', 'ReferenceField'
+]
 
 
 class CharField(MongoBaseField):
@@ -788,39 +801,6 @@ class ListField(MongoBaseField):
 #
 # Geospatial field types.
 #
-
-class GeoJSONField(MongoBaseField):
-    """Base class for GeoJSON fields."""
-
-    def __init__(self, verbose_name=None, mongo_name=None, **kwargs):
-        """
-        :parameters:
-          - `verbose_name`: A human-readable name for the Field.
-          - `mongo_name`: The name of this field when stored in MongoDB.
-
-        .. seealso:: constructor for
-                     :class:`~pymodm.base.fields.MongoBaseField`
-        """
-        super(GeoJSONField, self).__init__(verbose_name=verbose_name,
-                                           mongo_name=mongo_name,
-                                           **kwargs)
-
-        self.validators.append(self.validate_geojson)
-
-    @classmethod
-    def validate_geojson(cls, value):
-        validators.validator_for_type(dict)(value)
-        validators.validator_for_geojson_type(
-            cls._geojson_name)(value)
-        coordinates = value.get('coordinates')
-        validators.validator_for_type(
-            (list, tuple), 'Coordinates')(coordinates)
-        cls.validate_coordinates(coordinates)
-
-    def to_python(self, value):
-        if isinstance(value, list):
-            return {'type': self._geojson_name, 'coordinates': value}
-        return value
 
 
 class PointField(GeoJSONField):


### PR DESCRIPTION
@shaneharvey @behackett @rozza

https://jira.mongodb.org/browse/PYMODM-25

Moving `GeoJSONField` from pymodm.fields into pymodm.base.fields, since it's a base field. Then, `pymodm.fields.__all__` lists every field type in the module.