### PR TITLE
PyMODM-31 - Allow specifying collations.

### DIFF
--- a/pymodm/base/options.py
+++ b/pymodm/base/options.py
@@ -23,7 +23,7 @@ from pymodm.fields import EmbeddedDocumentField, EmbeddedDocumentListField
 DEFAULT_NAMES = (
     'connection_alias', 'collection_name', 'codec_options', 'final',
     'cascade', 'read_preference', 'read_concern', 'write_concern',
-    'indexes')
+    'indexes', 'collation')
 
 
 class MongoOptions(object):
@@ -48,6 +48,7 @@ class MongoOptions(object):
         self.read_concern = None
         self.write_concern = None
         self.indexes = []
+        self.collation = None
         self._auto_dereference = True
 
     @property

--- a/pymodm/queryset.py
+++ b/pymodm/queryset.py
@@ -40,6 +40,7 @@ class QuerySet(object):
         self._projection = None
         self._return_raw = False
         self._select_related_fields = None
+        self._collation = self._model._mongometa.collation
         # Select all subclasses of the given Model.
         self._types_query = {}
         if not self._model._mongometa.final:
@@ -57,7 +58,7 @@ class QuerySet(object):
         """Return an identical copy of this QuerySet."""
         clone_properties = (
             '_order_by', '_limit', '_skip', '_projection', '_return_raw',
-            '_select_related_fields')
+            '_select_related_fields', '_collation')
 
         clone = QuerySet(model=model or self._model, query=query or self._query)
 
@@ -113,7 +114,8 @@ class QuerySet(object):
     def count(self):
         """Return the number of objects in this QuerySet."""
         return self._collection.count(
-            self.raw_query, skip=self._skip, limit=self._limit)
+            self.raw_query, skip=self._skip, limit=self._limit,
+            collation=self._collation)
 
     def first(self):
         """Return the first object from this QuerySet."""
@@ -165,6 +167,8 @@ class QuerySet(object):
             before_pipeline.append({'$skip': self._skip})
         if self._limit:
             before_pipeline.append({'$limit': self._limit})
+
+        kwargs.setdefault('collation', self._collation)
 
         return self._collection.aggregate(
             before_pipeline + list(pipeline), **kwargs)
@@ -294,6 +298,20 @@ class QuerySet(object):
         clone._return_raw = True
         return clone
 
+    def collation(self, collation):
+        """Specify a collation to use for string comparisons.
+
+        This will override the default collation of the collection.
+
+        :parameters:
+          - `collation`: An instance of `~pymongo.collation.Collation` or a
+            ``dict`` specifying the collation.
+
+        """
+        clone = self._clone()
+        clone._collation = collation
+        return clone
+
     #
     # Object-manipulation methods.
     #
@@ -396,7 +414,8 @@ class QuerySet(object):
 
             # If we've made it this far, it's ok to delete the objects in this
             # QuerySet.
-            result = self._collection.delete_many(self._query).deleted_count
+            result = self._collection.delete_many(
+                self._query, collation=self._collation).deleted_count
 
             # Apply the rest of the delete rules.
             for rule_entry in self._model._mongometa.delete_rules:
@@ -416,7 +435,8 @@ class QuerySet(object):
 
             return result
 
-        return self._collection.delete_many(self._query).deleted_count
+        return self._collection.delete_many(
+            self._query, collation=self._collation).deleted_count
 
     def update(self, update, **kwargs):
         """Update the objects in this QuerySet and return the number updated.
@@ -438,6 +458,7 @@ class QuerySet(object):
         if kwargs.get('upsert') and not self._model._mongometa.final:
             dollar_set = update.setdefault('$set', {})
             dollar_set['_cls'] = self._model._mongometa.object_name
+        kwargs.setdefault('collation', self._collation)
         return self._collection.update_many(
             self.raw_query, update, **kwargs).modified_count
 
@@ -458,7 +479,8 @@ class QuerySet(object):
             sort=self._order_by,
             limit=self._limit,
             skip=self._skip,
-            projection=self._projection)
+            projection=self._projection,
+            collation=self._collation)
 
     def __iter__(self):
         if self._return_raw:

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ CLASSIFIERS = [
 ]
 
 
-requires = ['pymongo>=3.2']
+requires = ['pymongo>=3.4']
 if sys.version_info[:2] == (2, 7):
     requires.append('ipaddress')
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -30,6 +30,10 @@ DB = CLIENT.odm_test
 
 connect('%s/%s' % (MONGO_URI, DB.name))
 
+# Get the version of MongoDB.
+server_info = pymongo.MongoClient(MONGO_URI).server_info()
+MONGO_VERSION = tuple(server_info.get('versionArray', []))
+
 
 class ODMTestCase(unittest.TestCase):
 

--- a/test/test_collation.py
+++ b/test/test_collation.py
@@ -1,9 +1,11 @@
 # -*- encoding: utf-8 -*-
 
+import unittest
+
 from pymongo.collation import Collation, CollationStrength
 from pymodm import fields, MongoModel
 
-from test import ODMTestCase
+from test import ODMTestCase, MONGO_VERSION
 
 
 class ModelForCollations(MongoModel):
@@ -15,6 +17,11 @@ class ModelForCollations(MongoModel):
 
 
 class CollationTestCase(ODMTestCase):
+
+    @classmethod
+    @unittest.skipIf(MONGO_VERSION < (3, 4), 'Requires MongoDB >= 3.4')
+    def setUpClass(cls):
+        super(CollationTestCase, cls).setUpClass()
 
     def setUp(self):
         # Initial data.

--- a/test/test_collation.py
+++ b/test/test_collation.py
@@ -1,0 +1,72 @@
+# -*- encoding: utf-8 -*-
+
+from pymongo.collation import Collation, CollationStrength
+from pymodm import fields, MongoModel
+
+from test import ODMTestCase
+
+
+class ModelForCollations(MongoModel):
+    name = fields.CharField()
+
+    class Meta:
+        # Default collation: American English, differentiate base characters.
+        collation = Collation('en_US', strength=CollationStrength.PRIMARY)
+
+
+class CollationTestCase(ODMTestCase):
+
+    def setUp(self):
+        # Initial data.
+        ModelForCollations._mongometa.collection.drop()
+        ModelForCollations.objects.bulk_create([
+            ModelForCollations(u'Aargren'),
+            ModelForCollations(u'Åårgren'),
+        ])
+
+    def test_collation(self):
+        # Use a different collation (not default) for this QuerySet.
+        qs = ModelForCollations.objects.collation(
+            Collation('en_US', strength=CollationStrength.TERTIARY))
+        self.assertEqual(1, qs.raw({'name': 'Aargren'}).count())
+
+    def test_count(self):
+        self.assertEqual(
+            2, ModelForCollations.objects.raw({'name': 'Aargren'}).count())
+
+    def test_aggregate(self):
+        self.assertEqual(
+            [{'name': u'Aargren'}, {'name': u'Åårgren'}],
+            list(ModelForCollations.objects.aggregate(
+                {'$match': {'name': 'Aargren'}},
+                {'$project': {'name': 1, '_id': 0}}
+            ))
+        )
+        # Override with keyword argument.
+        alternate_collation = Collation(
+            'en_US', strength=CollationStrength.TERTIARY)
+        self.assertEqual(
+            [{'name': u'Aargren'}],
+            list(ModelForCollations.objects.aggregate(
+                {'$match': {'name': 'Aargren'}},
+                {'$project': {'name': 1, '_id': 0}},
+                collation=alternate_collation)))
+
+    def test_delete(self):
+        self.assertEqual(2, ModelForCollations.objects.delete())
+
+    def test_update(self):
+        self.assertEqual(2, ModelForCollations.objects.raw(
+            {'name': 'Aargren'}).update({'$set': {'touched': 1}}))
+        # Override with keyword argument.
+        alternate_collation = Collation(
+            'en_US', strength=CollationStrength.TERTIARY)
+        self.assertEqual(
+            1, ModelForCollations.objects.raw({'name': 'Aargren'}).update(
+                {'$set': {'touched': 2}},
+                collation=alternate_collation))
+
+    def test_query(self):
+        qs = ModelForCollations.objects.raw({'name': 'Aargren'})
+        # Iterate the QuerySet.
+        self.assertEqual(2, sum(1 for _ in qs))


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYMODM-31

@behackett @ShaneHarvey @rozza 

This adds a `collation` helper to QuerySet and also allows setting a default collation for a model.

Example usage:

```python
class User(MongoModel):
    name = CharField()

    class Meta:
        # Set a default collation for User.
        collation = {'locale': 'en_US'}

# Using the default collation:
User.objects.raw({'name': {'$gt': u'Åargren'}})

# Specify a different collation on a QuerySet:
User.objects.collation({'locale': 'sv'}).raw({'name': {'$gt': u'Åargren'}})
```

This also updates the PyMongo dependency to 3.4, which hasn't come out yet, so the tests will fail on this PR until it is released.

