### PR TITLE
PyMODM-38 - Add "project" method to QuerySet.

### DIFF
--- a/pymodm/queryset.py
+++ b/pymodm/queryset.py
@@ -16,7 +16,7 @@ import copy
 
 from pymodm import errors
 from pymodm.common import (
-    _import, validate_boolean, validate_list_or_tuple)
+    _import, validate_boolean, validate_list_or_tuple, validate_mapping)
 
 
 class QuerySet(object):
@@ -218,6 +218,33 @@ class QuerySet(object):
         """
         clone = self._clone()
         clone._order_by = ordering
+        return clone
+
+    def project(self, projection):
+        """Specify a raw MongoDB projection to use in QuerySet results.
+
+        This method overrides any previous projections on this QuerySet,
+        including those created with :meth:`~pymodm.queryset.QuerySet.only` and
+        :meth:`~pymodm.queryset.QuerySet.exclude`. Unlike these methods,
+        `project` allows projecting out the primary key. However, note that
+        objects that do not have their primary key cannot be re-saved to the
+        database.
+
+        :parameters:
+          - `projection`: A MongoDB projection document.
+
+        example::
+
+            >>> Vacation.objects.project({
+            ...     'destination': 1,
+            ...     'flights': {'$elemMatch': {'available': True}}}).first()
+            Vacation(destination='HAWAII',
+                     flights=[{'available': True, 'from': 'SFO'}])
+
+        """
+        projection = validate_mapping('projection', projection)
+        clone = self._clone()
+        clone._projection = projection
         return clone
 
     def only(self, *fields):

--- a/test/test_queryset.py
+++ b/test/test_queryset.py
@@ -92,6 +92,13 @@ class QuerySetTestCase(ODMTestCase):
         self.assertEqual('Amarth', results[2].lname)
         self.assertEqual('Tomato', results[3].lname)
 
+    def test_project(self):
+        results = User.objects.project({'lname': 1})
+        for result in results:
+            self.assertIsNotNone(result.lname)
+            self.assertIsNotNone(result.pk)
+            self.assertIsNone(result.phone)
+
     def test_only(self):
         results = User.objects.only('phone')
         for result in results:


### PR DESCRIPTION
@behackett @rozza @ShaneHarvey 

https://jira.mongodb.org/browse/PYMODM-38

The `project` method fills a need for more complex projections (e.g. `$slice`, `$elemMatch`), as compared to `only`/`exclude` which only allow turning on/off fields directly.