### PR TITLE
PyMODM-40 - DateTimeField should accept numeric timestamps.

### DIFF
--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -241,8 +241,11 @@ class DateTimeField(MongoBaseField):
             parsed = parse_datetime(value)
             if parsed is not None:
                 return parsed
-        raise ValidationError(
-            '%r cannot be converted to a datetime object.' % value)
+        try:
+            return datetime.datetime.utcfromtimestamp(value)
+        except TypeError:
+            raise ValidationError(
+                '%r cannot be converted to a datetime object.' % value)
 
     def to_python(self, value):
         try:

--- a/test/field_types/test_datetime_field.py
+++ b/test/field_types/test_datetime_field.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import time
 
 from bson.tz_util import utc, FixedOffset
 
@@ -79,14 +80,18 @@ class DateTimeFieldTestCase(FieldTestCase):
             datetime.datetime(2006, 7, 2),
             datetime.date(2006, 7, 2))
 
+        now = time.time()
+        self.assertConversion(
+            self.field,
+            datetime.datetime.utcfromtimestamp(now),
+            now)
+
         for expected, to_convert in DATETIME_CASES:
             self.assertConversion(self.field, expected, to_convert)
 
     def test_validate(self):
         msg = 'cannot be converted to a datetime object'
         invalid_values = [
-            # Inconvertible type.
-            22,
             # Microseconds without seconds.
             '2006-7-2T123.456',
             # Nonsense timezone.


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYMODM-40

@rozza @behackett @ShaneHarvey 
