### PR TITLE
Pymodm django support (WIP)

### DIFF
--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -101,6 +101,10 @@ class MongoBaseField(object):
     def verbose_name(self):
         return self._verbose_name or self.attname or self.mongo_name
 
+    @verbose_name.setter
+    def verbose_name(self, name):
+        self._verbose_name = name
+
     def to_python(self, value):
         """Coerce the raw value for this field to an appropriate Python type.
 

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -392,69 +392,7 @@ class MongoModelBase(object):
         return NotImplemented
 
 
-class MongoModel(with_metaclass(TopLevelMongoModelMetaclass, MongoModelBase)):
-    """Base class for all top-level models.
-
-    A MongoModel definition typically includes a number of field instances
-    and possibly a ``Meta`` class attribute that provides metadata or settings
-    specific to the model.
-
-    MongoModels can be instantiated either with positional or keyword arguments.
-    Positional arguments are bound to the fields in the order the fields are
-    defined on the model. Keyword argument names are the same as the names of
-    the fields::
-
-        from pymongo.read_preferences import ReadPreference
-
-        class User(MongoModel):
-            email = fields.EmailField(primary_key=True)
-            name = fields.CharField()
-
-            class Meta:
-                # Read from secondaries.
-                read_preference = ReadPreference.SECONDARY
-
-        # Instantiate User using positional arguments:
-        jane = User('jane@janesemailaddress.net', 'Jane')
-        # Keyword arguments:
-        roy = User(name='Roy', email='roy@roysemailaddress.net')
-
-    Note that :func:`~pymodm.connection.connect` has to be called (defining the
-    respective connection alias, if any) before any :class:`~pymodm.MongoModel`
-    can be used with that alias. If ``indexes`` is defined on ``Meta``, then
-    this has to be before the MongoModel class is evaluated.
-
-    .. _metadata-attributes:
-
-    The following metadata attributes are available:
-
-      - `connection_alias`: The alias of the connection to use for the moel.
-      - `collection_name`: The name of the collection to use. By default, this
-        is the same name as the model, converted to snake case.
-      - `codec_options`: An instance of
-        :class:`~bson.codec_options.CodecOptions` to use for reading and writing
-        documents of this model type.
-      - `final`: Whether to restrict inheritance on this model. If ``True``, the
-        ``_cls`` field will not be stored in the document. ``False`` by
-        default.
-      - `cascade`: If ``True``, save all :class:`~pymodm.MongoModel` instances
-        this object references when :meth:`~pymodm.MongoModel.save` is called
-        on this object.
-      - `read_preference`: The :class:`~pymongo.read_preferences.ReadPreference`
-        to use when reading documents.
-      - `read_concern`: The :class:`~pymongo.read_concern.ReadConcern` to use
-        when reading documents.
-      - `write_concern`: The :class:`~pymongo.write_concern.WriteConcern` to use
-        for write operations.
-      - `indexes`: This is a list of :class:`~pymongo.operations.IndexModel`
-        instances that describe the indexes that should be created for this
-        model. Indexes are created when the class definition is evaluated.
-
-    .. note:: Creating an instance of MongoModel does not create a document in
-              the database.
-
-    """
-
+class TopLevelMongoModel(MongoModelBase):
     @classmethod
     def register_delete_rule(cls, related_model, related_field, rule):
         """Specify what to do when an instance of this class is deleted.
@@ -581,6 +519,72 @@ class MongoModel(with_metaclass(TopLevelMongoModelMetaclass, MongoModelBase)):
             elif isinstance(other, DBRef):
                 return self.pk == other.id
         return self is other
+
+
+class MongoModel(
+        with_metaclass(TopLevelMongoModelMetaclass, TopLevelMongoModel)):
+    """Base class for all top-level models.
+
+    A MongoModel definition typically includes a number of field instances
+    and possibly a ``Meta`` class attribute that provides metadata or settings
+    specific to the model.
+
+    MongoModels can be instantiated either with positional or keyword arguments.
+    Positional arguments are bound to the fields in the order the fields are
+    defined on the model. Keyword argument names are the same as the names of
+    the fields::
+
+        from pymongo.read_preferences import ReadPreference
+
+        class User(MongoModel):
+            email = fields.EmailField(primary_key=True)
+            name = fields.CharField()
+
+            class Meta:
+                # Read from secondaries.
+                read_preference = ReadPreference.SECONDARY
+
+        # Instantiate User using positional arguments:
+        jane = User('jane@janesemailaddress.net', 'Jane')
+        # Keyword arguments:
+        roy = User(name='Roy', email='roy@roysemailaddress.net')
+
+    Note that :func:`~pymodm.connection.connect` has to be called (defining the
+    respective connection alias, if any) before any :class:`~pymodm.MongoModel`
+    can be used with that alias. If ``indexes`` is defined on ``Meta``, then
+    this has to be before the MongoModel class is evaluated.
+
+    .. _metadata-attributes:
+
+    The following metadata attributes are available:
+
+      - `connection_alias`: The alias of the connection to use for the moel.
+      - `collection_name`: The name of the collection to use. By default, this
+        is the same name as the model, converted to snake case.
+      - `codec_options`: An instance of
+        :class:`~bson.codec_options.CodecOptions` to use for reading and writing
+        documents of this model type.
+      - `final`: Whether to restrict inheritance on this model. If ``True``, the
+        ``_cls`` field will not be stored in the document. ``False`` by
+        default.
+      - `cascade`: If ``True``, save all :class:`~pymodm.MongoModel` instances
+        this object references when :meth:`~pymodm.MongoModel.save` is called
+        on this object.
+      - `read_preference`: The :class:`~pymongo.read_preferences.ReadPreference`
+        to use when reading documents.
+      - `read_concern`: The :class:`~pymongo.read_concern.ReadConcern` to use
+        when reading documents.
+      - `write_concern`: The :class:`~pymongo.write_concern.WriteConcern` to use
+        for write operations.
+      - `indexes`: This is a list of :class:`~pymongo.operations.IndexModel`
+        instances that describe the indexes that should be created for this
+        model. Indexes are created when the class definition is evaluated.
+
+    .. note:: Creating an instance of MongoModel does not create a document in
+              the database.
+
+    """
+    pass
 
 
 class EmbeddedMongoModel(with_metaclass(MongoModelMetaclass, MongoModelBase)):

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -156,7 +156,7 @@ class TopLevelMongoModelMetaclass(MongoModelMetaclass):
         if manager is None:
             manager = Manager()
             new_class.add_to_class('objects', manager)
-        new_class._default_manager = manager
+        new_class._mongometa.default_manager = manager
 
         # Create any indexes defined in our options.
         indexes = new_class._mongometa.indexes
@@ -479,7 +479,7 @@ class MongoModel(with_metaclass(TopLevelMongoModelMetaclass, MongoModelBase)):
             self.__queryset = None
         if (self.__queryset is None and
                 not self._mongometa.pk.is_undefined(self)):
-            self.__queryset = self.__class__._default_manager.raw(
+            self.__queryset = self.__class__._mongometa.default_manager.raw(
                 {'_id': self._mongometa.pk.to_mongo(self.pk)})
         return self.__queryset
 

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -47,7 +47,10 @@ class MongoModelMetaclass(type):
 
         # User-defined or inherited metadata
         meta = attrs.get('Meta', getattr(new_class, 'Meta', None))
-        options = MongoOptions(meta)
+        # Allow the options class to be pluggable.
+        # Pop it from attrs, since it's not useful in the final class.
+        options_class = attrs.pop('_options_class', MongoOptions)
+        options = options_class(meta)
 
         # Let the Options object take care of merging relevant options.
         new_class.add_to_class('_mongometa', options)

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -142,8 +142,14 @@ class MongoModelMetaclass(type):
 class TopLevelMongoModelMetaclass(MongoModelMetaclass):
     """Metaclass for all top-level (i.e. not embedded) Models."""
     def __new__(mcls, name, bases, attrs):
+        # Allow the manager class to be pluggable.
+        # Pop it from attrs now, so that the class doesn't become an attribute
+        # of the new class.
+        manager_class = attrs.pop('_manager_class', Manager)
+
         new_class = super(TopLevelMongoModelMetaclass, mcls).__new__(
             mcls, name, bases, attrs)
+
         # Conceptually the same as 'if new_class is MongoModelBase'.
         if not hasattr(new_class, '_mongometa'):
             return new_class
@@ -157,7 +163,7 @@ class TopLevelMongoModelMetaclass(MongoModelMetaclass):
         # Add QuerySet Manager.
         manager = new_class._find_manager()
         if manager is None:
-            manager = Manager()
+            manager = manager_class()
             new_class.add_to_class('objects', manager)
         new_class._mongometa.default_manager = manager
 

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -230,12 +230,13 @@ class MongoModelBase(object):
     def _find_referenced_objects(self, value):
         """Find all referenced objects in the given object."""
         references = []
-        if isinstance(value, MongoModel):
+        if isinstance(value, TopLevelMongoModel):
             references.append(value)
         elif isinstance(value, list):
             for item in value:
                 references.extend(self._find_referenced_objects(item))
-        elif isinstance(value, EmbeddedMongoModel):
+        elif isinstance(value, MongoModelBase):
+            # EmbeddedMongoModel
             for field_name in value:
                 field_value = getattr(value, field_name)
                 references.extend(value._find_referenced_objects(field_value))

--- a/pymodm/base/options.py
+++ b/pymodm/base/options.py
@@ -86,8 +86,14 @@ class MongoOptions(object):
 
     def add_field(self, field_inst):
         """Add or replace a given Field."""
-        orig_field = (self.get_field(field_inst.mongo_name) or
-                      self.get_field_from_attname(field_inst.attname))
+        try:
+            orig_field = self.get_field(field_inst.mongo_name)
+        except Exception:
+            # FieldDoesNotExist, etc.
+            try:
+                orig_field = self.get_field_from_attname(field_inst.attname)
+            except Exception:
+                orig_field = None
         if orig_field:
             if field_inst.attname != orig_field.attname:
                 raise InvalidModel('%r cannot have the same mongo_name of '

--- a/pymodm/base/options.py
+++ b/pymodm/base/options.py
@@ -90,10 +90,13 @@ class MongoOptions(object):
             orig_field = self.get_field(field_inst.mongo_name)
         except Exception:
             # FieldDoesNotExist, etc. may be raised by subclasses.
+            orig_field = None
+        if orig_field is None:
             try:
                 orig_field = self.get_field_from_attname(field_inst.attname)
             except Exception:
-                orig_field = None
+                pass
+
         if orig_field:
             if field_inst.attname != orig_field.attname:
                 raise InvalidModel('%r cannot have the same mongo_name of '

--- a/pymodm/base/options.py
+++ b/pymodm/base/options.py
@@ -89,7 +89,7 @@ class MongoOptions(object):
         try:
             orig_field = self.get_field(field_inst.mongo_name)
         except Exception:
-            # FieldDoesNotExist, etc.
+            # FieldDoesNotExist, etc. may be raised by subclasses.
             try:
                 orig_field = self.get_field_from_attname(field_inst.attname)
             except Exception:

--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -1151,10 +1151,10 @@ class ReferenceField(RelatedModelFieldsBase):
                                              verbose_name=verbose_name,
                                              mongo_name=mongo_name,
                                              **kwargs)
-        MongoModel = _import('pymodm.base.models.MongoModel')
+        TopLevelMongoModel = _import('pymodm.base.models.TopLevelMongoModel')
         if (ReferenceField.DO_NOTHING != on_delete and
             not (isinstance(model, type) and
-                 issubclass(model, MongoModel))):
+                 issubclass(model, TopLevelMongoModel))):
             raise ValueError(
                 'Cannot specify on_delete without providing a Model class '
                 'for model (was: %r). For bidirectional delete rules, '

--- a/pymodm/manager.py
+++ b/pymodm/manager.py
@@ -48,8 +48,8 @@ class BaseManager(object):
 
     def __get__(self, instance, cls):
         """Only let Manager be accessible from Model classes."""
-        MongoModel = _import('pymodm.base.models.MongoModel')
-        if isinstance(instance, MongoModel):
+        TopLevelMongoModel = _import('pymodm.base.models.TopLevelMongoModel')
+        if isinstance(instance, TopLevelMongoModel):
             raise AttributeError(
                 "Manager isn't accessible via %s instances." % (cls.__name__,))
         return self

--- a/pymodm/queryset.py
+++ b/pymodm/queryset.py
@@ -396,8 +396,8 @@ class QuerySet(object):
         """
         retrieve = validate_boolean('retrieve', retrieve)
         full_clean = validate_boolean('full_clean', full_clean)
-        MongoModel = _import('pymodm.base.models.MongoModel')
-        if isinstance(object_or_objects, MongoModel):
+        TopLevelMongoModel = _import('pymodm.base.models.TopLevelMongoModel')
+        if isinstance(object_or_objects, TopLevelMongoModel):
             object_or_objects = [object_or_objects]
         object_or_objects = validate_list_or_tuple(
             'object_or_objects', object_or_objects)

--- a/pymodm/queryset.py
+++ b/pymodm/queryset.py
@@ -430,7 +430,7 @@ class QuerySet(object):
                 related_model, related_field = rule_entry
                 rule = self._model._mongometa.delete_rules[rule_entry]
                 if ReferenceField.DENY == rule:
-                    related_qs = related_model._default_manager.raw(
+                    related_qs = related_model._mongometa.default_manager.raw(
                         {related_field: {'$in': refs}}).values()
                     if related_qs.count() > 0:
                         raise errors.OperationError(
@@ -451,7 +451,7 @@ class QuerySet(object):
                 rule = self._model._mongometa.delete_rules[rule_entry]
                 if ReferenceField.DO_NOTHING == rule:
                     continue
-                related_qs = (related_model._default_manager
+                related_qs = (related_model._mongometa.default_manager
                               .raw({related_field: {'$in': refs}})
                               .values())
                 if ReferenceField.NULLIFY == rule:

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -48,7 +48,8 @@ class ManagerTestCase(ODMTestCase):
         # Check that our custom Manager was installed.
         self.assertIsInstance(BookCredit.contributors, CustomManager)
         # Contributors should be the default manager, not more_contributors.
-        self.assertIs(BookCredit.contributors, BookCredit._default_manager)
+        self.assertIs(BookCredit.contributors,
+                      BookCredit._mongometa.default_manager)
 
     def test_get_queryset(self):
         self.assertIsInstance(

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -82,3 +82,8 @@ class MongoOptionsTestCase(ODMTestCase):
         # Replace a Field.
         options.add_field(fields.ObjectIdField(mongo_name='id'))
         self.assertIsInstance(options.get_fields()[-1], fields.ObjectIdField)
+        # Replace a field with a different mongo_name, but same attname.
+        new_field = fields.ObjectIdField(mongo_name='newid')
+        new_field.attname = 'id'
+        options.add_field(new_field)
+        self.assertEqual(len(options.get_fields()), 2)


### PR DESCRIPTION
Changes related to bootstrapping Django support:

* Split out MongoModel into base class (without metaclass) and full implementation (with metaclass). This allows us to reuse TopLevelMongoModel without running into metaclass conflicts in pymodm-django.
* Allow manager class to be pluggable, by passing it along in attrs to the metaclass.
* Allow options metadata class to be pluggable, by passing it along in attrs to the metaclass.
* Install default_manager on MongoOptions, rather than on the model class directly.
* Allow verbose_name on fields to be mutable.