### PR TITLE
PyMODM-48 - Allow unknown fields when parsing documents

### DIFF
--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -254,10 +254,7 @@ class MongoModelBase(object):
                 continue
             elif '_id' == field and not self._mongometa.implicit_id:
                 setattr(self, self._mongometa.pk.attname, dict[field])
-            elif field not in field_names:
-                raise ValueError(
-                    'Unrecognized field name %r' % field)
-            else:
+            elif field in field_names:
                 setattr(self, field_names[field], dict[field])
 
     @classmethod

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -581,7 +581,7 @@ class MongoModel(
       - `indexes`: This is a list of :class:`~pymongo.operations.IndexModel`
         instances that describe the indexes that should be created for this
         model. Indexes are created when the class definition is evaluated.
-      - `ignore_unkown_fields`: If ``True``, fields that aren't defined in the
+      - `ignore_unknown_fields`: If ``True``, fields that aren't defined in the
         model will be ignored when parsing documents from MongoDB, such as in
         :meth:`~pymodm.MongoModel.from_document`. By default, unknown fields
         will cause a ``ValueError`` to be raised. Note that with this option

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -249,6 +249,7 @@ class MongoModelBase(object):
             field.mongo_name: field.attname
             for field in self._mongometa.get_fields()
         }
+        ignore_unknown = self._mongometa.ignore_unknown_fields
         for field in dict:
             if '_cls' == field:
                 continue
@@ -256,6 +257,9 @@ class MongoModelBase(object):
                 setattr(self, self._mongometa.pk.attname, dict[field])
             elif field in field_names:
                 setattr(self, field_names[field], dict[field])
+            elif not ignore_unknown:
+                raise ValueError(
+                    'Unrecognized field name %r' % field)
 
     @classmethod
     def from_document(cls, document):
@@ -577,6 +581,12 @@ class MongoModel(
       - `indexes`: This is a list of :class:`~pymongo.operations.IndexModel`
         instances that describe the indexes that should be created for this
         model. Indexes are created when the class definition is evaluated.
+      - `ignore_unkown_fields`: If ``True``, fields that aren't defined in the
+        model will be ignored when parsing documents from MongoDB, such as in
+        :meth:`~pymodm.MongoModel.from_document`. By default, unknown fields
+        will cause a ``ValueError`` to be raised. Note that with this option
+        enabled, calling :meth:`~pymodm.MongoModel.save` will erase these
+        fields for that model instance.
 
     .. note:: Creating an instance of MongoModel does not create a document in
               the database.

--- a/pymodm/base/options.py
+++ b/pymodm/base/options.py
@@ -24,7 +24,7 @@ from pymodm.fields import EmbeddedDocumentField, EmbeddedDocumentListField
 DEFAULT_NAMES = (
     'connection_alias', 'collection_name', 'codec_options', 'final',
     'cascade', 'read_preference', 'read_concern', 'write_concern',
-    'indexes', 'collation')
+    'indexes', 'collation', 'ignore_unknown_fields')
 
 
 class MongoOptions(object):
@@ -51,6 +51,7 @@ class MongoOptions(object):
         self.write_concern = None
         self.indexes = []
         self.collation = None
+        self.ignore_unknown_fields = False
         self._auto_dereference = True
 
     @property

--- a/test/test_model_basic.py
+++ b/test/test_model_basic.py
@@ -100,6 +100,16 @@ class BasicModelTestCase(ODMTestCase):
         class Document(MongoModel):
             name = CharField()
 
+        with self.assertRaisesRegex(ValueError, 'Unrecognized field .*age'):
+            retrieved = Document.objects.raw({'name': 'Test'}).first()
+
+        # Redefine document, this time ignoring unknown fields.
+        class Document(MongoModel):
+            name = CharField()
+
+            class Meta:
+                ignore_unknown_fields = True
+
         # No error.
         retrieved = Document.objects.raw({'name': 'Test'}).first()
 

--- a/test/test_model_basic.py
+++ b/test/test_model_basic.py
@@ -15,7 +15,7 @@
 from test import ODMTestCase, DB
 from test.models import User
 
-from pymodm import MongoModel, CharField
+from pymodm import MongoModel, CharField, IntegerField
 from pymodm.errors import InvalidModel, ValidationError
 
 
@@ -88,3 +88,20 @@ class BasicModelTestCase(ODMTestCase):
         self.assertIn('fname', message)
         self.assertIsInstance(message['fname'], list)
         self.assertIn('field is required.', message['fname'])
+
+    def test_remove_field_from_model(self):
+        class Document(MongoModel):
+            name = CharField()
+            age = IntegerField()
+
+        Document('Test', 42).save()
+
+        # Redefine Document.
+        class Document(MongoModel):
+            name = CharField()
+
+        # No error.
+        retrieved = Document.objects.raw({'name': 'Test'}).first()
+
+        self.assertEqual('Test', retrieved.name)
+        self.assertRaises(AttributeError, getattr, retrieved, 'age')

--- a/test/test_model_basic.py
+++ b/test/test_model_basic.py
@@ -105,3 +105,6 @@ class BasicModelTestCase(ODMTestCase):
 
         self.assertEqual('Test', retrieved.name)
         self.assertRaises(AttributeError, getattr, retrieved, 'age')
+
+        retrieved.save()
+        self.assertNotIn('age', DB.document.find_one())


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYMODM-48

Disallowing unknown fields seemed like the right choice at first, but now there are complaints about this decision (including http://stackoverflow.com/q/41472478/3271558). In the future, we could make validating unexpected fields optional, by creating a new option on the `class Meta`. I'm going to hold of on doing so until there's a clear need for that, though.