### PR TITLE
PyMODM-50 - Fix handling of Field.mongo_name

### DIFF
--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -58,7 +58,7 @@ class MongoModelMetaclass(type):
 
         def should_inherit_field(parent_class, field):
             # Never shadow fields defined on the new class.
-            if field.attname in new_class._mongometa.fields_dict:
+            if field.attname in new_class._mongometa.fields_attname_dict:
                 return False
             # Never inherit an implicit primary key.
             if field.primary_key and parent_class._mongometa.implicit_id:

--- a/pymodm/base/options.py
+++ b/pymodm/base/options.py
@@ -17,6 +17,7 @@ from bisect import bisect
 from bson.codec_options import CodecOptions
 
 from pymodm.connection import _get_db, DEFAULT_CONNECTION_ALIAS
+from pymodm.errors import InvalidModel
 from pymodm.fields import EmbeddedDocumentField, EmbeddedDocumentListField
 
 # Attributes that can be user-specified in MongoOptions.
@@ -35,6 +36,7 @@ class MongoOptions(object):
         self.collection_name = None
         self.codec_options = CodecOptions()
         self.fields_dict = {}
+        self.fields_attname_dict = {}
         self.fields_ordered = []
         self.implicit_id = False
         self.delete_rules = {}
@@ -75,23 +77,41 @@ class MongoOptions(object):
         self._auto_dereference = auto_dereference
 
     def get_field(self, field_name):
-        """Retrieve a Field instance with the given name."""
+        """Retrieve a Field instance with the given MongoDB name."""
         return self.fields_dict.get(field_name)
+
+    def get_field_from_attname(self, attname):
+        """Retrieve a Fields instance with the given attribute name."""
+        return self.fields_attname_dict.get(attname)
+
+    def _add_field(self, field_inst):
+        """Helper for add_field."""
+        self.fields_dict[field_inst.mongo_name] = field_inst
+        self.fields_attname_dict[field_inst.attname] = field_inst
+        index = bisect(self.fields_ordered, field_inst)
+        self.fields_ordered.insert(index, field_inst)
 
     def add_field(self, field_inst):
         """Add or replace a Field with a given name."""
         field_name = field_inst.mongo_name
+        attname = field_inst.attname
         if field_name in self.fields_dict:
-            # Replace a field with the same name.
+            # Replace a field with the same MongoDB name.
             orig_field = self.fields_dict[field_name]
-            self.fields_dict[field_name] = field_inst
+            if attname != orig_field.attname:
+                raise InvalidModel('%r cannot have the same mongo_name of '
+                                   'existing field %r' % (attname,
+                                                          orig_field.attname))
             self.fields_ordered.remove(orig_field)
-            index = bisect(self.fields_ordered, field_inst)
-            self.fields_ordered.insert(index, field_inst)
+            self._add_field(field_inst)
+        elif attname in self.fields_attname_dict:
+            # Replace a field with the same attribute name.
+            orig_field = self.fields_attname_dict[attname]
+            self.fields_dict.pop(orig_field.mongo_name, None)
+            self.fields_ordered.remove(orig_field)
+            self._add_field(field_inst)
         else:
-            index = bisect(self.fields_ordered, field_inst)
-            self.fields_ordered.insert(index, field_inst)
-            self.fields_dict[field_name] = field_inst
+            self._add_field(field_inst)
         # Set the primary key if we don't have one yet, or it if is implicit.
         if field_inst.primary_key and self.pk is None or self.implicit_id:
             self.pk = field_inst

--- a/test/test_model_basic.py
+++ b/test/test_model_basic.py
@@ -16,6 +16,7 @@ from test import ODMTestCase, DB
 from test.models import User
 
 from pymodm import MongoModel, CharField
+from pymodm.errors import InvalidModel
 
 
 class BasicModelTestCase(ODMTestCase):
@@ -57,3 +58,10 @@ class BasicModelTestCase(ODMTestCase):
         # No exception.
         instance.full_clean()
         self.assertIsNone(instance.field)
+
+    def test_same_mongo_name(self):
+        msg = '.* cannot have the same mongo_name of existing field .*'
+        with self.assertRaisesRegex(InvalidModel, msg):
+            class SameMongoName(MongoModel):
+                field = CharField()
+                new_field = CharField(mongo_name='field')

--- a/test/test_model_basic.py
+++ b/test/test_model_basic.py
@@ -62,11 +62,13 @@ class BasicModelTestCase(ODMTestCase):
     def test_same_mongo_name(self):
         msg = '.* cannot have the same mongo_name of existing field .*'
         with self.assertRaisesRegex(InvalidModel, msg):
-            class SameMongoName(User):
-                address = CharField(mongo_name='lname')
+            class SameMongoName(MongoModel):
+                field = CharField()
+                new_field = CharField(mongo_name='field')
 
-        class Model(MongoModel):
+        class Parent(MongoModel):
             field = CharField(mongo_name='child_field')
+
         with self.assertRaisesRegex(InvalidModel, msg):
-            class SameMongoName(Model):
+            class SameMongoNameAsParent(Parent):
                 child_field = CharField()

--- a/test/test_model_basic.py
+++ b/test/test_model_basic.py
@@ -62,6 +62,11 @@ class BasicModelTestCase(ODMTestCase):
     def test_same_mongo_name(self):
         msg = '.* cannot have the same mongo_name of existing field .*'
         with self.assertRaisesRegex(InvalidModel, msg):
-            class SameMongoName(MongoModel):
-                field = CharField()
-                new_field = CharField(mongo_name='field')
+            class SameMongoName(User):
+                address = CharField(mongo_name='lname')
+
+        class Model(MongoModel):
+            field = CharField(mongo_name='child_field')
+        with self.assertRaisesRegex(InvalidModel, msg):
+            class SameMongoName(Model):
+                child_field = CharField()

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -20,6 +20,11 @@ from test import ODMTestCase
 from test.models import ParentModel, UserOtherCollection, User
 
 
+class Renamed(User):
+    # Override existing field and change mongo_name
+    address = fields.CharField(mongo_name='mongo_address')
+
+
 class MongoOptionsTestCase(ODMTestCase):
 
     def test_metadata(self):
@@ -53,6 +58,18 @@ class MongoOptionsTestCase(ODMTestCase):
     def test_get_field(self):
         self.assertIs(
             User.address, User._mongometa.get_field('address'))
+        self.assertIs(
+            Renamed.address, Renamed._mongometa.get_field('mongo_address'))
+        self.assertIsNone(Renamed._mongometa.get_field('address'))
+
+    def test_get_field_from_attname(self):
+        self.assertIs(
+            User.address, User._mongometa.get_field_from_attname('address'))
+        self.assertIs(
+            Renamed.address,
+            Renamed._mongometa.get_field_from_attname('address'))
+        self.assertIsNone(
+            Renamed._mongometa.get_field_from_attname('mongo_address'))
 
     def test_add_field(self):
         options = MongoOptions()


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYMODM-50

Model can override an existing field and change the 'mongo_name'.
Two fields cannot have the same 'mongo_name'.
Add get_field_from_attname helper to MongoOptions.