### PR TITLE
Fix dereferencing embedded documents refs and dereferencing tests. 

### DIFF
--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -185,6 +185,8 @@ class MongoBaseField(object):
         self.attname = name
         self.mongo_name = self.mongo_name or name
         self.model = cls
+        if self.primary_key and not cls._mongometa.implicit_id:
+            self.required = True
         cls._mongometa.add_field(self)
         setattr(cls, name, self)
 

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -148,8 +148,8 @@ class TopLevelMongoModelMetaclass(MongoModelMetaclass):
         # Check for a primary key field. If there isn't one, put one there.
         if new_class._mongometa.pk is None:
             id_field = ObjectIdField(primary_key=True)
-            new_class.add_to_class('_id', id_field)
             new_class._mongometa.implicit_id = True
+            new_class.add_to_class('_id', id_field)
 
         # Add QuerySet Manager.
         manager = new_class._find_manager()

--- a/pymodm/dereference.py
+++ b/pymodm/dereference.py
@@ -139,7 +139,7 @@ def _attach_objects_in_path(container, document_map, path=None):
         value = _get_value(container, part)
         _set_or_recurse(container, document_map, path, part, value)
     # Recurse on every field, if there's no path given.
-    elif hasattr(container, 'items'):
+    elif hasattr(container, 'items') or isinstance(container, MongoModelBase):
         # Container is a dict or a MongoModel of some kind.
         # Both iterate their keys.
         for key in container:

--- a/pymodm/queryset.py
+++ b/pymodm/queryset.py
@@ -60,7 +60,8 @@ class QuerySet(object):
             '_order_by', '_limit', '_skip', '_projection', '_return_raw',
             '_select_related_fields', '_collation')
 
-        clone = QuerySet(model=model or self._model, query=query or self._query)
+        clone = type(self)(model=model or self._model,
+                           query=query or self._query)
 
         for prop in clone_properties:
             setattr(clone, prop, copy.copy(getattr(self, prop)))

--- a/test/test_dereference.py
+++ b/test/test_dereference.py
@@ -166,9 +166,10 @@ class DereferenceTestCase(ODMTestCase):
         dereference(hand)
 
     def test_reference_not_found(self):
-        post = Post().save()
+        post = Post(title='title').save()
         comment = Comment(body='this is a comment', post=post).save()
         post.delete()
+        self.assertEqual(Post.objects.count(), 0)
         comment.refresh_from_db()
         self.assertIsNone(comment.post)
 

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -68,7 +68,7 @@ class FieldsTestCase(ODMTestCase):
 
     def test_field_dbname(self):
         self.assertEqual('firstName', Person.first_name.mongo_name)
-        Person(first_name='Han').save()
+        Person(email='han@site.com', first_name='Han').save()
         self.assertEqual(
             'Han',
             DB.person.find_one().get('firstName'))
@@ -96,18 +96,18 @@ class FieldsTestCase(ODMTestCase):
             retrieved)
 
     def test_model_validation(self):
-        person = Person(first_name='Luke', ssn='nan')
+        person = Person(email='luke@site.com', first_name='Luke', ssn='nan')
         with self.assertRaises(ValidationError):
             # SSN cannot be turned into an int.
             person.full_clean()
 
-        person = Person(first_name='Luke', ssn=42)
+        person = Person(email='luke@site.com', first_name='Luke', ssn=42)
         with self.assertRaises(ValidationError):
             # SSN is out of range.
             person.full_clean()
 
     def test_custom_validators(self):
-        person = Person(first_name='leia')
+        person = Person(email='leia@site.com', first_name='leia')
         with self.assertRaises(ValidationError):
             # Names have to be capitalized.
             person.full_clean()
@@ -125,14 +125,20 @@ class FieldsTestCase(ODMTestCase):
 
     def test_field_choices(self):
         # Ok.
-        Student(first_name='Joe', year='freshman').full_clean()
+        Student(
+            email='joe@site.com',
+            first_name='Joe',
+            year='freshman').full_clean()
         # Not a choice.
         with self.assertRaisesRegex(ValidationError, 'not a choice'):
             Student(year='sixth-year').full_clean()
 
     def test_field_choices_2d(self):
         # Ok.
-        Student2d(first_name='Bernard', year=Student2d.FRESHMAN).full_clean()
+        Student2d(
+            email='bernard@site.com',
+            first_name='Bernard',
+            year=Student2d.FRESHMAN).full_clean()
         # Not a choice.
         with self.assertRaisesRegex(ValidationError, 'not a choice'):
             Student2d(year='freshman').full_clean()
@@ -140,7 +146,8 @@ class FieldsTestCase(ODMTestCase):
     def test_required(self):
         # Positive cases tested in other tests.
         with self.assertRaisesRegex(ValidationError, 'field is required'):
-            Student2d(year=Student2d.FRESHMAN).full_clean()
+            Student2d(
+                email="bob@site.com", year=Student2d.FRESHMAN).full_clean()
 
     def test_set_empty(self):
         inst = Simple('a string with more than zero characters').save()


### PR DESCRIPTION
What does these changes do:
---------------------------------
1) Fix bug with dereference function: it does not dereference refs in embedded documents from list ``ListField(EmbeddedDoc(ReferenceField(X)))``. It performs an additional call to db using dereference_id function while accessing the field.
    - Add test to reproduce.
    - Add fix.
2) Fix false positive ``test test.test_dereference.DereferenceTestCase.test_reference_not_found``. It saves an empty ``Post`` model which has title as a pk. That forces to store post document with _id as an ``ObjectId``. So ``post.delete()`` does not actually delete any documents from database.