### PR TITLE
Add auto_create_indexes Meta option and QuerySet.create_indexes method.

### DIFF
--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -160,7 +160,7 @@ class TopLevelMongoModelMetaclass(MongoModelMetaclass):
 
         # Create any indexes defined in our options.
         indexes = new_class._mongometa.indexes
-        if indexes:
+        if indexes and new_class._mongometa.auto_create_indexes:
             new_class._mongometa.collection.create_indexes(indexes)
 
         return new_class
@@ -429,7 +429,9 @@ class MongoModel(with_metaclass(TopLevelMongoModelMetaclass, MongoModelBase)):
         for write operations.
       - `indexes`: This is a list of :class:`~pymongo.operations.IndexModel`
         instances that describe the indexes that should be created for this
-        model. Indexes are created when the class definition is evaluated.
+        model.
+      - `auto_create_indexes`: If ``True``, indexes will be created when the
+        class definition is evaluated. ``True`` by default.
 
     .. note:: Creating an instance of MongoModel does not create a document in
               the database.

--- a/pymodm/base/options.py
+++ b/pymodm/base/options.py
@@ -24,7 +24,7 @@ from pymodm.fields import EmbeddedDocumentField, EmbeddedDocumentListField
 DEFAULT_NAMES = (
     'connection_alias', 'collection_name', 'codec_options', 'final',
     'cascade', 'read_preference', 'read_concern', 'write_concern',
-    'indexes', 'collation')
+    'indexes', 'collation', 'auto_create_indexes')
 
 
 class MongoOptions(object):
@@ -51,6 +51,7 @@ class MongoOptions(object):
         self.write_concern = None
         self.indexes = []
         self.collation = None
+        self.auto_create_indexes = True
         self._auto_dereference = True
 
     @property

--- a/pymodm/queryset.py
+++ b/pymodm/queryset.py
@@ -490,6 +490,34 @@ class QuerySet(object):
         return self._collection.update_many(
             self.raw_query, update, **kwargs).modified_count
 
+    def create_indexes(self):
+        """Create any indexes defined in model's Meta.
+
+        Note that this method can be used with context managers
+        from :mod:`~pymodm.context_managers`.
+
+        example::
+
+            from pymodm import MongoModel, CharField
+            from pymongo import IndexModel, ASCENDING
+
+            class User(MongoModel):
+                name = CharField()
+
+                class Meta:
+                    indexes = [
+                        IndexModel([('name', ASCENDING)])
+                    ]
+
+            def create_indexes():
+                # here we create indexes for each model
+                User.objects.create_indexes()
+
+        """
+        indexes = self._model._mongometa.indexes
+        if indexes:
+            self._model._mongometa.collection.create_indexes(indexes)
+
     #
     # Helper methods
     #

--- a/test/test_model_indexes.py
+++ b/test/test_model_indexes.py
@@ -1,0 +1,122 @@
+from pymodm import fields, MongoModel, connect
+from pymodm.context_managers import switch_collection, switch_connection
+from pymongo import IndexModel, ASCENDING
+
+from test import ODMTestCase, DB, MONGO_URI, CLIENT
+
+
+class ModelIndexesTestCase(ODMTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.db_name = 'alternate-db'
+        connect(MONGO_URI + '/' + cls.db_name, 'backups')
+        cls.db = CLIENT[cls.db_name]
+
+    @classmethod
+    def tearDownClass(cls):
+        CLIENT.drop_database(cls.db_name)
+
+    def test_indexes_with_auto_create_indexes_option_on(self):
+        class ModelWithAutoIndexes(MongoModel):
+            product_id = fields.UUIDField()
+            name = fields.CharField()
+
+            class Meta:
+                auto_create_indexes = True
+                indexes = [
+                    IndexModel([('product_id', 1), ('name', 1)],
+                               unique=True, name='product_name')
+                ]
+
+        index_info = DB.model_with_auto_indexes.index_information()
+        self.assertTrue(index_info['product_name']['unique'])
+
+    def test_indexes_with_auto_create_indexes_option_off(self):
+        class ModelWithIndexes(MongoModel):
+            product_id = fields.UUIDField()
+            name = fields.CharField()
+
+            class Meta:
+                auto_create_indexes = False
+                indexes = [
+                    IndexModel([('product_id', 1), ('name', 1)],
+                               unique=True, name='product_name')
+                ]
+
+        # ensure collection is created
+        ModelWithIndexes().save()
+
+        index_info = DB.model_with_indexes.index_information()
+        self.assertNotIn('product_name', index_info)
+
+        # create indexes explicitly
+        ModelWithIndexes.objects.create_indexes()
+        index_info = DB.model_with_indexes.index_information()
+        self.assertTrue(index_info['product_name']['unique'])
+
+    def test_indexes_with_default_auto_create_indexes_option(self):
+        class ModelWithAutoIndexes(MongoModel):
+            product_id = fields.UUIDField()
+            name = fields.CharField()
+
+            class Meta:
+                indexes = [
+                    IndexModel([('product_id', 1), ('name', 1)],
+                               unique=True, name='product_name')
+                ]
+
+        # by default auto_create_indexes option should be True
+        index_info = DB.model_with_auto_indexes.index_information()
+        self.assertTrue(index_info['product_name']['unique'])
+
+    def test_create_indexes_with_no_indexes_defined(self):
+        class ModelWithoutIndexes(MongoModel):
+            name = fields.CharField()
+
+        # should not raise any error
+        ModelWithoutIndexes.objects.create_indexes()
+
+    def test_create_indexes_with_switch_collection_context_manager(self):
+        class User(MongoModel):
+            fname = fields.CharField()
+
+            class Meta:
+                auto_create_indexes = False
+                indexes = [
+                    IndexModel([('fname', ASCENDING)], name="fname_index")
+                ]
+
+        # ensure collection exists
+        User(fname='Bob').save()
+
+        with switch_collection(User, 'copied_user') as CopiedUser:
+            CopiedUser.objects.create_indexes()
+
+        index_info = DB.copied_user.index_information()
+        self.assertIn('fname_index', index_info)
+
+        index_info = DB.user.index_information()
+        self.assertNotIn('fname_index', index_info)
+
+    def test_create_indexes_with_switch_connection_context_manager(self):
+        class User(MongoModel):
+            fname = fields.CharField()
+
+            class Meta:
+                auto_create_indexes = False
+                indexes = [
+                    IndexModel([('fname', ASCENDING)], name="fname_index")
+                ]
+
+        # ensure collection exists
+        User(fname='Bob').save()
+
+        with switch_connection(User, 'backups') as BackupUser:
+            BackupUser.objects.create_indexes()
+
+        index_info = self.db.user.index_information()
+        self.assertIn('fname_index', index_info)
+
+        index_info = DB.user.index_information()
+        self.assertNotIn('fname_index', index_info)


### PR DESCRIPTION
What do these changes do:
------------------------------
- Add ``auto_create_indexes`` option to control whether model's indexes
  should be created when model class definition is evaluated or not. The default value is ``True`` so that default behavior would be fully compatible with current one. With this option it is possible to control indexes creation and makes models classes definition independent from ``connect`` function call before any model class (mainly with indexes) is evaluated. 
- Add ``QuerySet.create_indexes`` method to explicitly create indexes
  which are defined in model's ``Meta``. As a bonus this method can be used with ``context_managers``.
- Add tests to test indexes creation.