### PR TITLE
PYMODM-54 - ReferenceField should guess type of pk.

### DIFF
--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -1197,8 +1197,8 @@ class ReferenceField(RelatedModelFieldsBase):
                 raise ValidationError(
                     'Referenced Models must be saved to the database first.')
             return value._mongometa.pk.to_mongo(value.pk)
-        # Assume value is the _id.
-        return value
+        # Assume value is some form of the _id.
+        return self.related_model._mongometa.pk.to_mongo(value)
 
     def __get__(self, inst, owner):
         MongoModelBase = _import('pymodm.base.models.MongoModelBase')

--- a/test/test_related_fields.py
+++ b/test/test_related_fields.py
@@ -187,3 +187,10 @@ class RelatedFieldsTestCase(ODMTestCase):
         post.refresh_from_db()
         self.assertEqual(
             post.images[0].photographer.thumbnail, photographer_thumbnail)
+
+    def test_coerce_reference_type(self):
+        post = Post('this is a post').save()
+        post_id = str(post.pk)
+        comment = Comment(body='this is a comment', post=post_id).save()
+        comment.refresh_from_db()
+        self.assertEqual('this is a post', comment.post.body)


### PR DESCRIPTION
Full description at https://jira.mongodb.org/browse/PYMODM-54

I found this while dealing with turning ReferenceFields into HTML form elements and parsing the form data in the request. The form element's value is a string, but this is never coerced back into the original pk type.