### PR TITLE
Fix dereference

### DIFF
--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -262,11 +262,16 @@ class MongoModelBase(object):
 
         """
         dct = validate_mapping('document', document)
+        doc_cls = cls
         cls_name = dct.get('_cls')
         if cls_name is not None:
-            cls = get_document(cls_name)
+            doc_cls = get_document(cls_name)
+            if not issubclass(doc_cls, cls):
+                raise TypeError('A document\'s _cls field must be '
+                                'a subclass of the %s, but %s is not.'
+                                % (doc_cls, cls))
 
-        inst = cls()
+        inst = doc_cls()
         inst._set_attributes(dct)
         return inst
 

--- a/pymodm/dereference.py
+++ b/pymodm/dereference.py
@@ -199,7 +199,7 @@ def dereference_id(model_class, model_id):
       - `model_class`: The class of a model to be dereferenced.
       - `model_id`: The id of the model to be dereferenced.
     """
-    collection = model_class._mongometa.collection
-    document = collection.find_one(model_id)
+    meta = model_class._mongometa
+    document = meta.collection.find_one({'_id': meta.pk.to_mongo(model_id)})
     if document:
         return model_class.from_document(document)

--- a/pymodm/dereference.py
+++ b/pymodm/dereference.py
@@ -98,6 +98,13 @@ def _resolve_references(database, reference_map):
         documents = collection.find(query)
         for document in documents:
             document_map[document['_id']] = document
+
+        # if there are no documents for some _id from
+        # reference_map set it to None
+        for _id in reference_map[collection_name]:
+            if _id not in document_map:
+                document_map[_id] = None
+
     return document_map
 
 

--- a/pymodm/dereference.py
+++ b/pymodm/dereference.py
@@ -99,19 +99,6 @@ def _resolve_references(database, reference_map):
     return document_map
 
 
-def _get_value(container, key):
-    if hasattr(container, '__getitem__'):
-        return container[key]
-    return getattr(container, key)
-
-
-def _set_value(container, key, value):
-    if hasattr(container, '__setitem__'):
-        container[key] = value
-    else:
-        setattr(container, key, value)
-
-
 def _get_reference_document(document_map, collection_name, ref_id):
     try:
         return document_map[collection_name][ref_id]
@@ -121,7 +108,7 @@ def _get_reference_document(document_map, collection_name, ref_id):
 
 def _attach_objects_in_path(container, document_map, fields, key, field):
     try:
-        value = _get_value(container, key)
+        value = container[key]
     except KeyError:
         # there is no value for given key
         return
@@ -130,11 +117,9 @@ def _attach_objects_in_path(container, document_map, fields, key, field):
             not isinstance(value, field.related_model)):
         # value is reference id
         meta = field.related_model._mongometa
-        collection_name = meta.collection_name
-        ref_id = meta.pk.to_mongo(value)
-        doc = _get_reference_document(document_map,
-                                      collection_name, ref_id)
-        _set_value(container, key, doc)
+        container[key] = _get_reference_document(document_map,
+                                                 meta.collection_name,
+                                                 meta.pk.to_mongo(value))
     elif isinstance(field, ListField):
         # value is list
         for idx, item in enumerate(value):

--- a/pymodm/dereference.py
+++ b/pymodm/dereference.py
@@ -95,10 +95,8 @@ def _find_references(model_instance, reference_map, fields=None):
 
 
 def _resolve_references(database, reference_map):
-    document_map = {}
+    document_map = defaultdict(_ObjectMap)
     for collection_name in reference_map:
-        document_map[collection_name] = _ObjectMap()
-
         collection = database[collection_name]
         query = {'_id': {'$in': reference_map[collection_name]}}
         documents = collection.find(query)

--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -1161,14 +1161,7 @@ class ReferenceField(RelatedModelFieldsBase):
                 'use MyModelClass.register_delete_rule instead.'
                 % model)
         self._on_delete = on_delete
-
-        def validate_related_model(ref):
-            """Given a Model, verify that it's been saved first."""
-            if isinstance(ref, self.related_model) and not ref.pk:
-                raise ValidationError(
-                    'Referenced documents must be saved to the database first.')
-
-        self.validators.append(validate_related_model)
+        self.validators.append(validators.validator_for_func(self.to_mongo))
 
     def contribute_to_class(self, cls, name):
         super(ReferenceField, self).contribute_to_class(cls, name)

--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -1161,7 +1161,6 @@ class ReferenceField(RelatedModelFieldsBase):
                 'use MyModelClass.register_delete_rule instead.'
                 % model)
         self._on_delete = on_delete
-        self._is_instance = False
 
         def validate_related_model(ref):
             """Given a Model, verify that it's been saved first."""
@@ -1213,6 +1212,4 @@ class ReferenceField(RelatedModelFieldsBase):
         return self
 
     def __set__(self, inst, value):
-        MongoModel = _import('pymodm.base.models.MongoModel')
         super(ReferenceField, self).__set__(inst, value)
-        self._is_instance = isinstance(value, MongoModel)

--- a/test/field_types/test_embedded_document_field.py
+++ b/test/field_types/test_embedded_document_field.py
@@ -14,6 +14,7 @@
 from bson import SON
 
 from pymodm import EmbeddedMongoModel
+from pymodm.errors import ValidationError
 from pymodm.fields import EmbeddedDocumentField, CharField
 
 from test.field_types import FieldTestCase
@@ -54,3 +55,9 @@ class EmbeddedDocumentFieldTestCase(FieldTestCase):
 
         self.assertIsInstance(value, SON)
         self.assertEqual(value, SON({'name': 'Bob'}))
+
+    def test_to_mongo_wrong_model(self):
+        with self.assertRaises(ValidationError) as cm:
+            self.field.to_mongo(1234)
+        exc = cm.exception
+        self.assertEqual(exc.message, '1234 is not a valid EmbeddedDocument')

--- a/test/field_types/test_embedded_document_field.py
+++ b/test/field_types/test_embedded_document_field.py
@@ -1,0 +1,56 @@
+# Copyright 2016 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from bson import SON
+
+from pymodm import EmbeddedMongoModel
+from pymodm.fields import EmbeddedDocumentField, CharField
+
+from test.field_types import FieldTestCase
+
+
+class EmbeddedDocument(EmbeddedMongoModel):
+    name = CharField()
+
+    class Meta:
+        final = True
+
+
+class EmbeddedDocumentFieldTestCase(FieldTestCase):
+
+    field = EmbeddedDocumentField(EmbeddedDocument)
+
+    def test_to_python(self):
+        value = self.field.to_python({'name': 'Bob'})
+        self.assertIsInstance(value, EmbeddedDocument)
+
+        doc = EmbeddedDocument(name='Bob')
+        value = self.field.to_python(doc)
+        self.assertIsInstance(value, EmbeddedDocument)
+        self.assertEqual(value, doc)
+
+    def test_to_mongo(self):
+        doc = EmbeddedDocument(name='Bob')
+        value = self.field.to_mongo(doc)
+        self.assertIsInstance(value, SON)
+        self.assertEqual(value, SON({'name': 'Bob'}))
+
+        son = value
+        value = self.field.to_mongo(son)
+        self.assertIsInstance(value, SON)
+        self.assertEqual(value, SON({'name': 'Bob'}))
+
+        value = self.field.to_mongo({'name': 'Bob'})
+
+        self.assertIsInstance(value, SON)
+        self.assertEqual(value, SON({'name': 'Bob'}))

--- a/test/field_types/test_embedded_document_list_field.py
+++ b/test/field_types/test_embedded_document_list_field.py
@@ -1,0 +1,78 @@
+# Copyright 2016 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from bson import SON
+
+from pymodm import EmbeddedMongoModel
+from pymodm.fields import EmbeddedDocumentListField, CharField
+
+from test.field_types import FieldTestCase
+
+
+class EmbeddedDocument(EmbeddedMongoModel):
+    name = CharField()
+
+    class Meta:
+        final = True
+
+
+class EmbeddedDocumentFieldTestCase(FieldTestCase):
+
+    field = EmbeddedDocumentListField(EmbeddedDocument)
+
+    def test_to_python(self):
+        # pass a raw list
+        value = self.field.to_python([{'name': 'Bob'}, {'name': 'Alice'}])
+
+        self.assertIsInstance(value, list)
+        self.assertIsInstance(value[0], EmbeddedDocument)
+        self.assertEqual(value[0].name, 'Bob')
+        self.assertIsInstance(value[1], EmbeddedDocument)
+        self.assertEqual(value[1].name, 'Alice')
+
+        # pass a list of models
+        bob = EmbeddedDocument(name='Bob')
+        alice = EmbeddedDocument(name='Alice')
+        value = self.field.to_python([bob, alice])
+
+        self.assertIsInstance(value, list)
+        self.assertIsInstance(value[0], EmbeddedDocument)
+        self.assertEqual(value[0].name, 'Bob')
+        self.assertIsInstance(value[1], EmbeddedDocument)
+        self.assertEqual(value[1].name, 'Alice')
+
+    def test_to_mongo(self):
+        bob = EmbeddedDocument(name='Bob')
+        alice = EmbeddedDocument(name='Alice')
+        emb_list = [bob, alice]
+        value = self.field.to_mongo(emb_list)
+        self.assertIsInstance(value, list)
+        self.assertIsInstance(value[0], SON)
+        self.assertEqual(value[0], SON({'name': 'Bob'}))
+        self.assertIsInstance(value[1], SON)
+        self.assertEqual(value[1], SON({'name': 'Alice'}))
+
+        son = value
+        value = self.field.to_mongo(son)
+        self.assertIsInstance(value, list)
+        self.assertIsInstance(value[0], SON)
+        self.assertEqual(value[0], SON({'name': 'Bob'}))
+        self.assertIsInstance(value[1], SON)
+        self.assertEqual(value[1], SON({'name': 'Alice'}))
+
+        value = self.field.to_mongo([{'name': 'Bob'}, alice])
+        self.assertIsInstance(value, list)
+        self.assertIsInstance(value[0], SON)
+        self.assertEqual(value[0], SON({'name': 'Bob'}))
+        self.assertIsInstance(value[1], SON)
+        self.assertEqual(value[1], SON({'name': 'Alice'}))

--- a/test/test_dereference.py
+++ b/test/test_dereference.py
@@ -164,11 +164,6 @@ class DereferenceTestCase(ODMTestCase):
         ]
         hand = Hand(cards).save()
 
-        # check auto_dereferncing
-        # hand.refresh_from_db()
-        # self.assertIsInstance(hand.cards[0], Card)
-        # self.assertIsInstance(hand.cards[1], Card)
-
         with no_auto_dereference(hand):
             hand.refresh_from_db()
             dereference(hand)
@@ -247,6 +242,7 @@ class DereferenceTestCase(ODMTestCase):
         self.assertEqual(Post.objects.count(), 0)
         comment.refresh_from_db()
         with no_auto_dereference(comment):
+            self.assertEqual(comment.post, 'title')
             dereference(comment)
             self.assertIsNone(comment.post)
 

--- a/test/test_dereference.py
+++ b/test/test_dereference.py
@@ -204,3 +204,13 @@ class DereferenceTestCase(ODMTestCase):
             'Aaron')
 
         self.assertEqual(container.lst[0].ref.name, 'Aaron')
+
+    def test_dereference_reference_not_found(self):
+        post = Post(title='title').save()
+        comment = Comment(body='this is a comment', post=post).save()
+        post.delete()
+        self.assertEqual(Post.objects.count(), 0)
+        comment.refresh_from_db()
+        with no_auto_dereference(Comment):
+            dereference(comment)
+            self.assertIsNone(comment.post)

--- a/test/test_dereference.py
+++ b/test/test_dereference.py
@@ -1,5 +1,4 @@
-from collections import OrderedDict
-from bson import ObjectId, DBRef
+from bson import ObjectId
 
 from pymodm.base import MongoModel, EmbeddedMongoModel
 from pymodm.context_managers import no_auto_dereference
@@ -268,29 +267,6 @@ class DereferenceTestCase(ODMTestCase):
             dereference(comment)
             self.assertIsInstance(comment.post, Post)
             self.assertIsInstance(comment.user, User)
-
-    def test_dereference_dbrefs(self):
-        class User(MongoModel):
-            post = fields.DictField()
-            posts = fields.OrderedDictField()
-
-        post = Post(title='title1').save()
-        collection_name = Post._mongometa.collection_name
-
-        post_value = {
-            'dbref': DBRef(id=post.title, collection=collection_name)
-        }
-        posts_value = OrderedDict([('dbref', [post_value['dbref'], ])])
-
-        user = User(post=post_value, posts=posts_value).save()
-
-        user.refresh_from_db()
-        with no_auto_dereference(user):
-            dereference(user)
-            self.assertIsInstance(user.post['dbref'], dict)
-            self.assertEqual(user.post['dbref']['_id'], post.title)
-            self.assertIsInstance(user.posts['dbref'][0], dict)
-            self.assertEqual(user.posts['dbref'][0]['_id'], post.title)
 
     def test_dereference_missed_reference_field(self):
         comment = Comment(body='Body Comment').save()

--- a/test/test_related_fields.py
+++ b/test/test_related_fields.py
@@ -85,7 +85,7 @@ class RelatedFieldsTestCase(ODMTestCase):
         message = cm.exception.message
         self.assertIn('post', message)
         self.assertEqual(
-            ['Referenced documents must be saved to the database first.'],
+            ['Referenced Models must be saved to the database first.'],
             message['post'])
 
         # Cannot save document when reference is unresolved.
@@ -93,7 +93,7 @@ class RelatedFieldsTestCase(ODMTestCase):
             comment.save()
         self.assertIn('post', message)
         self.assertEqual(
-            ['Referenced documents must be saved to the database first.'],
+            ['Referenced Models must be saved to the database first.'],
             message['post'])
 
     def test_embedded_document(self):

--- a/test/test_related_fields.py
+++ b/test/test_related_fields.py
@@ -57,7 +57,7 @@ class RelatedFieldsTestCase(ODMTestCase):
 
     def test_assign_id_to_reference_field(self):
         # No ValidationError raised.
-        Comment(post=1234).full_clean()
+        Comment(post="58b477046e32ab215dca2b57").full_clean()
 
     def test_validate_embedded_document(self):
         with self.assertRaisesRegex(ValidationError, 'field is required'):


### PR DESCRIPTION
What do these changes do:
----------------------------

- Remove ``ReferenceField._is_instance`` property as it is useless (field is
  shared between model instances).
- Rewrite dereferencing to fix some issues:
  - Dereference unhashable ids (auto dereferencing still does not work for
    this case as reference id is treated as dereferenced document not as an id).
  - Set reference field value to ``None`` if there is no document with such
    id (as auto dereferencing does).
  - Fix bug when some fields reference to different collections but have
    the same id. So that only one of that field will be set with correct
    value as the document_map was {id --> document}. Example:
```python
class User(MongoModel):
    name = fields.CharField(primary_key=True)
class Category(MongoModel):
    title = fields.CharField(primary_key=True)
class Post(MongoModel):
    user = fields.ReferenceField(User)
    category = fields.ReferenceField(Category)
user = User(name='Bob').save()
category = Category(title='Bob').save()
post = Post(user=user, category=category)
with no_auto_dereference(post):
    post.refresh_from_db()
    dereference(post)
    # one of the follow statements will fail as both post.user and post.category
    # will be User (or Category).
    assert isinstance(post.user, User)
    assert isinstance(post.category, Category)
```
  - Dereference DBRefs in dict-like fields. As there is no field for DBRef the only way to store it 
is within dict-like fields (``DictField``, ``OrderedDictField``). So dereference traverses such containers to find ``DBRef``  values and try to dererference them.