### PR TITLE
PyMODM-56 add QuerySet.reverse()

### DIFF
--- a/pymodm/common.py
+++ b/pymodm/common.py
@@ -17,6 +17,8 @@ import re
 from collections import Mapping
 from importlib import import_module
 
+import pymongo
+
 from pymodm.errors import ModelDoesNotExist
 
 from pymodm.compat import string_types
@@ -140,3 +142,17 @@ def validate_mapping(option, value):
         raise TypeError('%s must be a Mapping, not a %s'
                         % (option, value.__class__.__name__))
     return value
+
+
+def validate_ordering(option, ordering):
+    ordering = validate_list_or_tuple(option, ordering)
+    for order in ordering:
+        order = validate_list_or_tuple(option + "'s elements", order)
+        if len(order) != 2:
+            raise ValueError("%s's elements must be (field_name, "
+                             "direction) not %s" % (option, order))
+        validate_string("field_name", order[0])
+        if order[1] not in (pymongo.ASCENDING, pymongo.DESCENDING):
+            raise ValueError("sort direction must be pymongo.ASCENDING or '"
+                             "pymongo.DECENDING not %s" % (order[1]))
+    return ordering

--- a/pymodm/queryset.py
+++ b/pymodm/queryset.py
@@ -14,9 +14,12 @@
 
 import copy
 
+import pymongo
+
 from pymodm import errors
 from pymodm.common import (
-    _import, validate_boolean, validate_list_or_tuple, validate_mapping)
+    _import, validate_boolean, validate_list_or_tuple, validate_mapping,
+    validate_ordering)
 
 
 class QuerySet(object):
@@ -221,8 +224,27 @@ class QuerySet(object):
             consisting of [(field_name, direction)], where "direction" can
             be one of :data:`~pymongo.ASCENDING` or :data:`~pymongo.DESCENDING`.
         """
+        ordering = validate_ordering('ordering', ordering)
         clone = self._clone()
         clone._order_by = ordering
+        return clone
+
+    def reverse(self):
+        """Reverse the ordering for this QuerySet.
+
+        If :meth:`~pymodm.queryset.QuerySet.order_by has not been called,
+        reverse() has no effect.
+        """
+        clone = self._clone()
+        if clone._order_by:
+            reversed_order_by = []
+            for field, order in clone._order_by:
+                if order == pymongo.ASCENDING:
+                    reversed_order = pymongo.DESCENDING
+                else:
+                    reversed_order = pymongo.ASCENDING
+                reversed_order_by.append((field, reversed_order))
+            clone._order_by = reversed_order_by
         return clone
 
     def project(self, projection):

--- a/pymodm/queryset.py
+++ b/pymodm/queryset.py
@@ -232,7 +232,7 @@ class QuerySet(object):
     def reverse(self):
         """Reverse the ordering for this QuerySet.
 
-        If :meth:`~pymodm.queryset.QuerySet.order_by has not been called,
+        If :meth:`~pymodm.queryset.QuerySet.order_by` has not been called,
         reverse() has no effect.
         """
         clone = self._clone()

--- a/test/test_queryset.py
+++ b/test/test_queryset.py
@@ -92,6 +92,28 @@ class QuerySetTestCase(ODMTestCase):
         self.assertEqual('Amarth', results[2].lname)
         self.assertEqual('Tomato', results[3].lname)
 
+    def test_order_by_validation(self):
+        with self.assertRaises(TypeError):
+            User.objects.order_by('not a list')
+        with self.assertRaises(TypeError):
+            User.objects.order_by([(1, 1)])
+        with self.assertRaises(ValueError):
+            User.objects.order_by([('field', 1, 'too many elements')])
+        with self.assertRaises(ValueError):
+            User.objects.order_by([('field', 2)])
+
+    def test_reverse(self):
+        def assert_reverses(qs):
+            normal_order = list(qs)
+            reversed_order = list(qs.reverse())
+            double_reversed = list(qs.reverse().reverse())
+            self.assertEqual(normal_order, list(reversed(reversed_order)))
+            self.assertEqual(normal_order, double_reversed)
+
+        assert_reverses(User.objects.order_by([('_id', 1)]))
+        assert_reverses(User.objects.order_by(
+            [('_id', 1), ('phone', -1), ('lname', 1)]))
+
     def test_project(self):
         results = User.objects.project({'lname': 1})
         for result in results:


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYMODM-56

These changes add a `QuerySet.reverse()` method to reverse to sort order provided in `QuerySet.order_by()`. It also adds validation of the ordering passed to `order_by`.