### PR TITLE
PyMODM-52 validate (Ordered)DictField keys are MongoDB compatible.

### DIFF
--- a/pymodm/common.py
+++ b/pymodm/common.py
@@ -90,12 +90,10 @@ def validate_string_or_none(option, value):
     return validate_string(option, value)
 
 
-def validate_mongo_field_name_or_none(option, value):
+def validate_mongo_field_name(option, value):
     """Validates the MongoDB field name format described in:
     https://docs.mongodb.com/manual/core/document/#field-names
     """
-    if value is None:
-        return value
     validate_string(option, value)
     if value == '':
         return value
@@ -109,6 +107,31 @@ def validate_mongo_field_name_or_none(option, value):
         raise ValueError('%s cannot contain the null character, %r.'
                          % (option, value))
     return value
+
+
+def validate_mongo_keys(option, dct):
+    """Recursively validate that all dictionary keys are valid in MongoDB."""
+    for key in dct:
+        validate_mongo_field_name(option, key)
+        value = dct[key]
+        if isinstance(value, dict):
+            validate_mongo_keys(option, value)
+        elif isinstance(value, (list, tuple)):
+            validate_mongo_keys_in_list(option, value)
+
+
+def validate_mongo_keys_in_list(option, lst):
+    for elem in lst:
+        if isinstance(elem, dict):
+            validate_mongo_keys(option, elem)
+        elif isinstance(elem, (list, tuple)):
+            validate_mongo_keys_in_list(option, elem)
+
+
+def validate_mongo_field_name_or_none(option, value):
+    if value is None:
+        return value
+    return validate_mongo_field_name(option, value)
 
 
 def validate_boolean(option, value):

--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -49,7 +49,7 @@ except ImportError:
 
 from pymodm import validators
 from pymodm.base.fields import RelatedModelFieldsBase, GeoJSONField
-from pymodm.common import _import
+from pymodm.common import _import, validate_mongo_keys
 from pymodm.compat import text_type, string_types, PY3
 from pymodm.connection import _get_db
 from pymodm.errors import ValidationError, ConfigurationError
@@ -701,15 +701,10 @@ class DictField(MongoBaseField):
 
         self.validators.append(self.to_mongo)
 
+        # Recursively validate that all dictionary keys are valid in MongoDB.
         def validate_keys(value):
-            for key in value:
-                if not isinstance(key, string_types):
-                    raise ValidationError(
-                        'All dictionary keys must be strings: %r' % value)
-                if '.' in key or '$' in key:
-                    raise ValidationError(
-                        'Dictionary keys must not contain "$" or ".": %r'
-                        % value)
+            validate_mongo_keys('Dictionary keys', value)
+
         self.validators.append(validate_keys)
 
     def to_mongo(self, value):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -35,6 +35,10 @@ server_info = pymongo.MongoClient(MONGO_URI).server_info()
 MONGO_VERSION = tuple(server_info.get('versionArray', []))
 
 
+INVALID_MONGO_NAMES = ['$dollar', 'has.dot', 'null\x00character']
+VALID_MONGO_NAMES = ['', 'dollar$', 'forty-two']
+
+
 class ODMTestCase(unittest.TestCase):
 
     def tearDown(self):

--- a/test/field_types/test_dict_field.py
+++ b/test/field_types/test_dict_field.py
@@ -15,6 +15,7 @@
 from pymodm.errors import ValidationError
 from pymodm.fields import DictField
 
+from test import INVALID_MONGO_NAMES, VALID_MONGO_NAMES
 from test.field_types import FieldTestCase
 
 
@@ -27,10 +28,21 @@ class DictFieldTestCase(FieldTestCase):
                               {'one': 1, 'two': 2}, {'one': 1, 'two': 2})
 
     def test_validate(self):
-        msg = 'All dictionary keys must be strings'
+        msg = 'Dictionary keys must be a string type, not a int'
         with self.assertRaisesRegex(ValidationError, msg):
             self.field.validate({42: 'forty-two'})
-        msg = 'Dictionary keys must not contain "\$" or "\."'
-        with self.assertRaisesRegex(ValidationError, msg):
-            self.field.validate({'foo.bar': 42})
-        self.field.validate({'forty-two': 42})
+
+        for invalid_mongo_name in INVALID_MONGO_NAMES:
+            msg = "Dictionary keys cannot .*"
+            with self.assertRaisesRegex(ValidationError, msg):
+                self.field.validate({invalid_mongo_name: 42})
+            # Invalid name in a sub dict.
+            with self.assertRaisesRegex(ValidationError, msg):
+                self.field.validate({'foo': {invalid_mongo_name: 42}})
+            # Invalid name in a sub dict inside an array.
+            with self.assertRaisesRegex(ValidationError, msg):
+                self.field.validate({'foo': [[{invalid_mongo_name: 42}]]})
+
+        for valid_mongo_name in VALID_MONGO_NAMES:
+            self.field.validate({valid_mongo_name: 42})
+            self.field.validate({valid_mongo_name: [{valid_mongo_name: 42}]})

--- a/test/field_types/test_ordereddict_field.py
+++ b/test/field_types/test_ordereddict_field.py
@@ -17,6 +17,7 @@ from collections import OrderedDict
 from pymodm.errors import ValidationError
 from pymodm.fields import OrderedDictField
 
+from test import INVALID_MONGO_NAMES, VALID_MONGO_NAMES
 from test.field_types import FieldTestCase
 
 
@@ -30,10 +31,21 @@ class OrderedDictFieldTestCase(FieldTestCase):
         self.assertConversion(self.field, data, {'one': 1, 'two': 2})
 
     def test_validate(self):
-        msg = 'All dictionary keys must be strings'
+        msg = 'Dictionary keys must be a string type, not a int'
         with self.assertRaisesRegex(ValidationError, msg):
             self.field.validate({42: 'forty-two'})
-        msg = 'Dictionary keys must not contain "\$" or "\."'
-        with self.assertRaisesRegex(ValidationError, msg):
-            self.field.validate({'foo.bar': 42})
-        self.field.validate({'forty-two': 42})
+
+        for invalid_mongo_name in INVALID_MONGO_NAMES:
+            msg = "Dictionary keys cannot .*"
+            with self.assertRaisesRegex(ValidationError, msg):
+                self.field.validate({invalid_mongo_name: 42})
+            # Invalid name in a sub dict.
+            with self.assertRaisesRegex(ValidationError, msg):
+                self.field.validate({'foo': {invalid_mongo_name: 42}})
+            # Invalid name in a sub dict inside an array.
+            with self.assertRaisesRegex(ValidationError, msg):
+                self.field.validate({'foo': [[{invalid_mongo_name: 42}]]})
+
+        for valid_mongo_name in VALID_MONGO_NAMES:
+            self.field.validate({valid_mongo_name: 42})
+            self.field.validate({valid_mongo_name: [{valid_mongo_name: 42}]})

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -19,7 +19,7 @@ import bson
 from pymodm import fields, MongoModel
 from pymodm.errors import ValidationError
 
-from test import ODMTestCase, DB
+from test import ODMTestCase, DB, INVALID_MONGO_NAMES, VALID_MONGO_NAMES
 
 
 def name_must_be_capitalized(name):
@@ -91,13 +91,12 @@ class FieldsTestCase(ODMTestCase):
                 _id = fields.CharField()
 
     def test_validate_mongo_name(self):
-        invalid_mongo_names = ['$dollar', 'has.dot', 'null\x00character']
-        for invalid_mongo_name in invalid_mongo_names:
+        for invalid_mongo_name in INVALID_MONGO_NAMES:
             with self.assertRaisesRegex(ValueError, 'mongo_name cannot .*'):
                 class InvalidMongoName(MongoModel):
                     field = fields.CharField(mongo_name=invalid_mongo_name)
-        valid_mongo_names = ['', 'dollar$', 'foo']
-        for valid_mongo_name in valid_mongo_names:
+
+        for valid_mongo_name in VALID_MONGO_NAMES:
             class ValidMongoName(MongoModel):
                 field = fields.CharField(mongo_name=valid_mongo_name)
             self.assertEqual(ValidMongoName.field.mongo_name,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYMODM-52

