### PR TITLE
PYMODM-42 - Allow field default to be a callable.

### DIFF
--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -43,7 +43,8 @@ class MongoBaseField(object):
           - `blank`: If ``True``, allow this field to have an empty value.
           - `required`: If ``True``, do not allow this field to be unspecified.
           - `default`: The default value to use for this field if no other value
-            has been given.
+            has been given. If ``default`` is callable, then the return value of
+            ``default()`` will be used as the default value.
           - `choices`: A list of possible values for the field. This can be a
             flat list, or a list of 2-tuples consisting of an allowed field
             value and a human-readable version of that value.
@@ -82,7 +83,7 @@ class MongoBaseField(object):
     def __get__(self, inst, owner):
         MongoModelBase = _import('pymodm.base.models.MongoModelBase')
         if inst is not None and isinstance(inst, MongoModelBase):
-            raw_value = inst._data.get(self.attname, self.default)
+            raw_value = inst._data.get(self.attname, self.get_default())
             if self.is_blank(raw_value):
                 return raw_value
             # Cache pythonized value.
@@ -97,6 +98,9 @@ class MongoBaseField(object):
 
     def __delete__(self, inst):
         inst._data.pop(self.attname, None)
+
+    def get_default(self):
+        return self.default() if callable(self.default) else self.default
 
     def is_blank(self, value):
         """Determine if the value is blank."""

--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -695,6 +695,7 @@ class DictField(MongoBaseField):
         .. seealso:: constructor for
                      :class:`~pymodm.base.fields.MongoBaseField`
         """
+        kwargs.setdefault('default', dict)
         super(DictField, self).__init__(verbose_name=verbose_name,
                                         mongo_name=mongo_name,
                                         **kwargs)
@@ -733,6 +734,7 @@ class OrderedDictField(DictField):
         .. seealso:: constructor for
                      :class:`~pymodm.base.fields.MongoBaseField`
         """
+        kwargs.setdefault('default', OrderedDict)
         super(OrderedDictField, self).__init__(verbose_name=verbose_name,
                                                mongo_name=mongo_name,
                                                **kwargs)
@@ -766,6 +768,7 @@ class ListField(MongoBaseField):
         .. seealso:: constructor for
                      :class:`~pymodm.base.fields.MongoBaseField`
         """
+        kwargs.setdefault('default', list)
         super(ListField, self).__init__(verbose_name=verbose_name,
                                         mongo_name=mongo_name,
                                         **kwargs)
@@ -1078,6 +1081,7 @@ class EmbeddedDocumentListField(RelatedModelFieldsBase):
         .. seealso:: constructor for
                      :class:`~pymodm.base.fields.MongoBaseField`
         """
+        kwargs.setdefault('default', list)
         super(EmbeddedDocumentListField, self).__init__(
             model=model,
             verbose_name=verbose_name,

--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -725,6 +725,9 @@ class DictField(MongoBaseField):
 
 class OrderedDictField(DictField):
     """A field that stores a :class:`~collections.OrderedDict`."""
+
+    empty_values = MongoBaseField.empty_values + [OrderedDict()]
+
     def __init__(self, verbose_name=None, mongo_name=None, **kwargs):
         """
         :parameters:

--- a/test/field_types/test_dict_field.py
+++ b/test/field_types/test_dict_field.py
@@ -46,3 +46,6 @@ class DictFieldTestCase(FieldTestCase):
         for valid_mongo_name in VALID_MONGO_NAMES:
             self.field.validate({valid_mongo_name: 42})
             self.field.validate({valid_mongo_name: [{valid_mongo_name: 42}]})
+
+    def test_get_default(self):
+        self.assertEqual({}, self.field.get_default())

--- a/test/field_types/test_embedded_document_list_field.py
+++ b/test/field_types/test_embedded_document_list_field.py
@@ -76,3 +76,6 @@ class EmbeddedDocumentFieldTestCase(FieldTestCase):
         self.assertEqual(value[0], SON({'name': 'Bob'}))
         self.assertIsInstance(value[1], SON)
         self.assertEqual(value[1], SON({'name': 'Alice'}))
+
+    def test_get_default(self):
+        self.assertEqual([], self.field.get_default())

--- a/test/field_types/test_list_field.py
+++ b/test/field_types/test_list_field.py
@@ -1,0 +1,35 @@
+# Copyright 2016 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pymodm.errors import ValidationError
+from pymodm.fields import ListField, IntegerField
+
+from test.field_types import FieldTestCase
+
+
+class ListFieldTestCase(FieldTestCase):
+
+    field = ListField(IntegerField(min_value=0))
+
+    def test_conversion(self):
+        self.assertConversion(self.field, [1, 2, 3], [1, 2, 3])
+        self.assertConversion(self.field, [1, 2, 3], ['1', '2', '3'])
+
+    def test_validate(self):
+        with self.assertRaisesRegex(ValidationError, 'less than minimum'):
+            self.field.validate([-1, 3, 4])
+        self.field.validate([1, 2, 3])
+
+    def test_get_default(self):
+        self.assertEqual([], self.field.get_default())

--- a/test/field_types/test_ordereddict_field.py
+++ b/test/field_types/test_ordereddict_field.py
@@ -52,3 +52,6 @@ class OrderedDictFieldTestCase(FieldTestCase):
 
     def test_get_default(self):
         self.assertEqual(OrderedDict(), self.field.get_default())
+
+    def test_blank(self):
+        self.assertTrue(self.field.is_blank(OrderedDict()))

--- a/test/field_types/test_ordereddict_field.py
+++ b/test/field_types/test_ordereddict_field.py
@@ -49,3 +49,6 @@ class OrderedDictFieldTestCase(FieldTestCase):
         for valid_mongo_name in VALID_MONGO_NAMES:
             self.field.validate({valid_mongo_name: 42})
             self.field.validate({valid_mongo_name: [{valid_mongo_name: 42}]})
+
+    def test_get_default(self):
+        self.assertEqual(OrderedDict(), self.field.get_default())

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import re
 
 import bson
@@ -234,3 +235,20 @@ class FieldsTestCase(ODMTestCase):
         self.assertEqual('Harold', inst.name)
         del inst.name
         self.assertEqual('Bozo', inst.name)
+
+    def test_callable_default(self):
+        now = datetime.datetime.now()
+
+        class CallableDefault(MongoModel):
+            date = fields.DateTimeField(default=lambda: now)
+
+        inst = CallableDefault()
+        self.assertEqual(now, inst.date)
+        earlier = datetime.datetime(year=1999, month=10, day=4)
+        inst.date = earlier
+        self.assertEqual(earlier, inst.date)
+        del inst.date
+        self.assertEqual(now, inst.date)
+
+        inst = CallableDefault().save()
+        self.assertEqual(now, inst.date)

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -252,3 +252,10 @@ class FieldsTestCase(ODMTestCase):
 
         inst = CallableDefault().save()
         self.assertEqual(now, inst.date)
+
+        # Default that is an empty value.
+        class CallableEmptyValue(MongoModel):
+            list_of_things = fields.ListField()
+
+        inst = CallableEmptyValue().save()
+        self.assertNotIn('list_of_things', DB.callable_empty_value.find_one())

--- a/test/test_queryset.py
+++ b/test/test_queryset.py
@@ -233,10 +233,10 @@ class QuerySetTestCase(ODMTestCase):
 
         with no_auto_dereference(Post):
             posts = list(Post.objects.all())
-            self.assertIsNone(posts[0].comments)
+            self.assertEqual([], posts[0].comments)
             self.assertIsInstance(posts[1].comments[0], ObjectId)
             self.assertIsInstance(posts[1].comments[1], ObjectId)
 
             posts = list(Post.objects.select_related())
-            self.assertIsNone(posts[0].comments)
+            self.assertEqual([], posts[0].comments)
             self.assertEqual(posts[1].comments, comments)


### PR DESCRIPTION
Change default values for DictField, OrderedDictField, ListField,
EmbeddedDocumentListField to be the empty value for their respective containers.