### PR TITLE
Call .get_default() only once (fixes: PyMODM-65)

### DIFF
--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -106,9 +106,12 @@ class MongoBaseField(object):
     def _get_default_once(self, inst):
         if not hasattr(inst, '_defaults'):
             inst._defaults = {}
-        if self.attname not in inst._defaults:
-            inst._defaults[self.attname] = self.get_default()
-        return inst._defaults[self.attname]
+        try:
+            return inst._defaults[self.attname]
+        except KeyError:
+            default = self.get_default()
+            inst._defaults[self.attname] = default
+            return default
 
     def is_blank(self, value):
         """Determine if the value is blank."""

--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -98,6 +98,7 @@ class MongoBaseField(object):
 
     def __delete__(self, inst):
         inst._data.pop(self.attname, None)
+        inst._defaults.pop(self.attname, None)
 
     def get_default(self):
         return self.default() if callable(self.default) else self.default

--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -83,7 +83,7 @@ class MongoBaseField(object):
     def __get__(self, inst, owner):
         MongoModelBase = _import('pymodm.base.models.MongoModelBase')
         if inst is not None and isinstance(inst, MongoModelBase):
-            raw_value = inst._data.get(self.attname, self.get_default())
+            raw_value = inst._data.get(self.attname, self._get_default_once(inst))
             if self.is_blank(raw_value):
                 return raw_value
             # Cache pythonized value.
@@ -101,6 +101,13 @@ class MongoBaseField(object):
 
     def get_default(self):
         return self.default() if callable(self.default) else self.default
+
+    def _get_default_once(self, inst):
+        if not hasattr(inst, '_defaults'):
+            inst._defaults = {}
+        if self.attname not in inst._defaults:
+            inst._defaults[self.attname] = self.get_default()
+        return inst._defaults[self.attname]
 
     def is_blank(self, value):
         """Determine if the value is blank."""

--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -104,8 +104,6 @@ class MongoBaseField(object):
         return self.default() if callable(self.default) else self.default
 
     def _get_default_once(self, inst):
-        if not hasattr(inst, '_defaults'):
-            inst._defaults = {}
         try:
             return inst._defaults[self.attname]
         except KeyError:

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -192,6 +192,8 @@ class MongoModelBase(object):
     def __init__(self, *args, **kwargs):
         # Initialize dict for saving field values.
         self._data = {}
+        # Initialize dict for saving field default values.
+        self._defaults = {}
 
         # Turn ordered arguments into keyword arguments.
         if args:

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -247,6 +247,7 @@ class MongoModelBase(object):
     def _set_attributes(self, dict):
         """Set this object's attributes from a dict."""
         self._data.clear()
+        self._defaults.clear()
         field_names = {
             field.mongo_name: field.attname
             for field in self._mongometa.get_fields()

--- a/test/field_types/test_list_field.py
+++ b/test/field_types/test_list_field.py
@@ -45,3 +45,8 @@ class ListFieldTestCase(FieldTestCase):
         article.tags.append('foo')
         article.tags.append('bar')
         self.assertEquals(article.tags, ['foo', 'bar'])
+
+        # Ensure tags is saved to the database.
+        article.save()
+        self.assertEqual(article.tags, self.Article.objects.first().tags)
+        self.assertEqual(self.Article().tags, [])

--- a/test/field_types/test_list_field.py
+++ b/test/field_types/test_list_field.py
@@ -56,6 +56,6 @@ class ListFieldTestCase(FieldTestCase):
         del article.tags
         self.assertEqual(article.tags, [])
 
-        # Ensure the deleted field is removed the database.
+        # Ensure the deleted field is removed from the database.
         article.save()
         self.assertNotIn('tags', DB.article.find_one())

--- a/test/field_types/test_list_field.py
+++ b/test/field_types/test_list_field.py
@@ -24,9 +24,6 @@ class ListFieldTestCase(FieldTestCase):
 
     field = ListField(IntegerField(min_value=0))
 
-    class Article(MongoModel):
-        tags = ListField(CharField())
-
     def test_conversion(self):
         self.assertConversion(self.field, [1, 2, 3], [1, 2, 3])
         self.assertConversion(self.field, [1, 2, 3], ['1', '2', '3'])
@@ -38,30 +35,3 @@ class ListFieldTestCase(FieldTestCase):
 
     def test_get_default(self):
         self.assertEqual([], self.field.get_default())
-
-    def test_mutable_default(self):
-        article = self.Article()
-        self.assertIs(article.tags, article.tags)
-
-        article.tags.append('foo')
-        article.tags.append('bar')
-        self.assertEqual(article.tags, ['foo', 'bar'])
-
-        # Ensure tags is saved to the database.
-        article.save()
-        self.assertEqual(article.tags, self.Article.objects.first().tags)
-        self.assertEqual(article.tags, ['foo', 'bar'])
-
-        # Ensure that deleting a field restores the default value.
-        del article.tags
-        self.assertEqual(article.tags, [])
-
-        # Ensure the deleted field is removed from the database.
-        article.save()
-        self.assertNotIn('tags', DB.article.find_one())
-
-        # Ensure that a refresh restores the default value.
-        article.tags.append('foo')
-        self.assertEqual(article.tags, ['foo'])
-        article.refresh_from_db()
-        self.assertEqual(article.tags, [])

--- a/test/field_types/test_list_field.py
+++ b/test/field_types/test_list_field.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pymodm import MongoModel
 from pymodm.errors import ValidationError
-from pymodm.fields import ListField, IntegerField
+from pymodm.fields import ListField, IntegerField, CharField
 
 from test.field_types import FieldTestCase
 
@@ -21,6 +22,9 @@ from test.field_types import FieldTestCase
 class ListFieldTestCase(FieldTestCase):
 
     field = ListField(IntegerField(min_value=0))
+
+    class Article(MongoModel):
+        tags = ListField(CharField())
 
     def test_conversion(self):
         self.assertConversion(self.field, [1, 2, 3], [1, 2, 3])
@@ -33,3 +37,11 @@ class ListFieldTestCase(FieldTestCase):
 
     def test_get_default(self):
         self.assertEqual([], self.field.get_default())
+
+    def test_mutable_default(self):
+        article = self.Article()
+        self.assertIs(article.tags, article.tags)
+
+        article.tags.append('foo')
+        article.tags.append('bar')
+        self.assertEquals(article.tags, ['foo', 'bar'])

--- a/test/field_types/test_list_field.py
+++ b/test/field_types/test_list_field.py
@@ -16,6 +16,7 @@ from pymodm import MongoModel
 from pymodm.errors import ValidationError
 from pymodm.fields import ListField, IntegerField, CharField
 
+from test import DB
 from test.field_types import FieldTestCase
 
 
@@ -44,9 +45,17 @@ class ListFieldTestCase(FieldTestCase):
 
         article.tags.append('foo')
         article.tags.append('bar')
-        self.assertEquals(article.tags, ['foo', 'bar'])
+        self.assertEqual(article.tags, ['foo', 'bar'])
 
         # Ensure tags is saved to the database.
         article.save()
         self.assertEqual(article.tags, self.Article.objects.first().tags)
-        self.assertEqual(self.Article().tags, [])
+        self.assertEqual(article.tags, ['foo', 'bar'])
+
+        # Ensure that deleting a field restores the default value.
+        del article.tags
+        self.assertEqual(article.tags, [])
+
+        # Ensure the deleted field is removed the database.
+        article.save()
+        self.assertNotIn('tags', DB.article.find_one())

--- a/test/field_types/test_list_field.py
+++ b/test/field_types/test_list_field.py
@@ -59,3 +59,9 @@ class ListFieldTestCase(FieldTestCase):
         # Ensure the deleted field is removed from the database.
         article.save()
         self.assertNotIn('tags', DB.article.find_one())
+
+        # Ensure that a refresh restores the default value.
+        article.tags.append('foo')
+        self.assertEqual(article.tags, ['foo'])
+        article.refresh_from_db()
+        self.assertEqual(article.tags, [])


### PR DESCRIPTION
At first I tried caching the default value in `inst._data`, but that broke a bunch of tests, because reading a default value of a field is not supposed to result in saving that default value to MongoDB.

So instead I added `inst._defaults`.  This doesn't get saved to MongoDB, but `__get__` reads from it instead of calling `.get_default()` again.