### PR TITLE
PYMODM-68 defer index creation

### DIFF
--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -167,11 +167,6 @@ class TopLevelMongoModelMetaclass(MongoModelMetaclass):
             new_class.add_to_class('objects', manager)
         new_class._mongometa.default_manager = manager
 
-        # Create any indexes defined in our options.
-        indexes = new_class._mongometa.indexes
-        if indexes:
-            new_class._mongometa.collection.create_indexes(indexes)
-
         return new_class
 
     def _find_manager(cls):

--- a/pymodm/base/options.py
+++ b/pymodm/base/options.py
@@ -53,15 +53,20 @@ class MongoOptions(object):
         self.collation = None
         self.ignore_unknown_fields = False
         self._auto_dereference = True
+        self._indexes_created = False
 
     @property
     def collection(self):
-        return _get_db(self.connection_alias).get_collection(
+        coll = _get_db(self.connection_alias).get_collection(
             self.collection_name,
             read_preference=self.read_preference,
             read_concern=self.read_concern,
             write_concern=self.write_concern,
             codec_options=self.codec_options)
+        if self.indexes and not self._indexes_created:
+            coll.create_indexes(self.indexes)
+            self._indexes_created = True
+        return coll
 
     @property
     def auto_dereference(self):

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,8 +1,42 @@
+from collections import defaultdict
 from pymodm.connection import connect, _get_connection
 from pymodm import MongoModel, CharField
 from pymongo import IndexModel
+from pymongo.monitoring import CommandListener, ServerHeartbeatListener
 
 from test import ODMTestCase
+
+
+class HeartbeatStartedListener(ServerHeartbeatListener):
+    def __init__(self):
+        self.results = []
+
+    def started(self, event):
+        self.results.append(event)
+
+    def succeeded(self, event):
+        pass
+
+    def failed(self, event):
+        pass
+
+
+class WhiteListEventListener(CommandListener):
+    def __init__(self, *commands):
+        self.commands = set(commands)
+        self.results = defaultdict(list)
+
+    def started(self, event):
+        if event.command_name in self.commands:
+            self.results['started'].append(event)
+
+    def succeeded(self, event):
+        if event.command_name in self.commands:
+            self.results['succeeded'].append(event)
+
+    def failed(self, event):
+        if event.command_name in self.commands:
+            self.results['failed'].append(event)
 
 
 class ConnectionTestCase(ODMTestCase):
@@ -15,24 +49,32 @@ class ConnectionTestCase(ODMTestCase):
         self.assertEqual(10, client.min_pool_size)
 
     def test_connect_lazily(self):
+        heartbeat_listener = HeartbeatStartedListener()
         connect('mongodb://localhost:27017/foo',
                 'foo-connection',
-                connect=False)
+                connect=False,
+                event_listeners=[heartbeat_listener])
         client = _get_connection('foo-connection').database.client
 
         class Article(MongoModel):
             title = CharField()
             class Meta:
                 connection_alias = 'foo-connection'
-        self.assertFalse(client._topology._opened)
 
+        # Creating the class didn't create a connection.
+        self.assertEqual(len(heartbeat_listener.results), 0)
+
+        # The connection is created on the first query.
         self.assertEqual(Article.objects.count(), 0)
-        self.assertTrue(client._topology._opened)
+        self.assertGreaterEqual(len(heartbeat_listener.results), 1)
 
     def test_connect_lazily_with_index(self):
+        heartbeat_listener = HeartbeatStartedListener()
+        create_indexes_listener = WhiteListEventListener('createIndexes')
         connect('mongodb://localhost:27017/foo',
                 'foo-connection',
-                connect=False)
+                connect=False,
+                event_listeners=[heartbeat_listener, create_indexes_listener])
         client = _get_connection('foo-connection').database.client
 
         class Article(MongoModel):
@@ -42,7 +84,12 @@ class ConnectionTestCase(ODMTestCase):
                 indexes = [
                     IndexModel([('title', 1)])
                 ]
-        self.assertFalse(client._topology._opened)
 
+        # Creating the class didn't create a connection, or any indexes.
+        self.assertEqual(len(heartbeat_listener.results), 0)
+        self.assertEqual(len(create_indexes_listener.results['started']), 0)
+
+        # The connection and indexes are created on the first query.
         self.assertEqual(Article.objects.count(), 0)
-        self.assertTrue(client._topology._opened)
+        self.assertGreaterEqual(len(heartbeat_listener.results), 1)
+        self.assertGreaterEqual(len(create_indexes_listener.results['started']), 1)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,4 +1,6 @@
 from pymodm.connection import connect, _get_connection
+from pymodm import MongoModel, CharField
+from pymongo import IndexModel
 
 from test import ODMTestCase
 
@@ -11,3 +13,36 @@ class ConnectionTestCase(ODMTestCase):
         client = _get_connection('foo-connection').database.client
         self.assertEqual(42, client.max_pool_size)
         self.assertEqual(10, client.min_pool_size)
+
+    def test_connect_lazily(self):
+        connect('mongodb://localhost:27017/foo',
+                'foo-connection',
+                connect=False)
+        client = _get_connection('foo-connection').database.client
+
+        class Article(MongoModel):
+            title = CharField()
+            class Meta:
+                connection_alias = 'foo-connection'
+        self.assertFalse(client._topology._opened)
+
+        self.assertEqual(Article.objects.count(), 0)
+        self.assertTrue(client._topology._opened)
+
+    def test_connect_lazily_with_index(self):
+        connect('mongodb://localhost:27017/foo',
+                'foo-connection',
+                connect=False)
+        client = _get_connection('foo-connection').database.client
+
+        class Article(MongoModel):
+            title = CharField()
+            class Meta:
+                connection_alias = 'foo-connection'
+                indexes = [
+                    IndexModel([('title', 1)])
+                ]
+        self.assertFalse(client._topology._opened)
+
+        self.assertEqual(Article.objects.count(), 0)
+        self.assertTrue(client._topology._opened)

--- a/test/test_model_inheritance.py
+++ b/test/test_model_inheritance.py
@@ -105,5 +105,8 @@ class ModelInheritanceTest(ODMTestCase):
         class ChildModel(ModelWithIndexes):
             pass
 
+        # force connection
+        ModelWithIndexes._mongometa.collection
+
         index_info = DB.model_with_indexes.index_information()
         self.assertTrue(index_info['product_id_1_name_1']['unique'])

--- a/test/test_model_inheritance.py
+++ b/test/test_model_inheritance.py
@@ -101,12 +101,21 @@ class ModelInheritanceTest(ODMTestCase):
                     IndexModel([('product_id', 1), ('name', 1)], unique=True)
                 ]
 
-        # No Exception.
         class ChildModel(ModelWithIndexes):
             pass
 
-        # force connection
-        ModelWithIndexes._mongometa.collection
+        # Creating a model class does not create the indexes.
+        index_info = DB.model_with_indexes.index_information()
+        self.assertNotIn('product_id_1_name_1', index_info)
 
+        # Indexes are only created once the Model's collection is accessed.
+        ModelWithIndexes._mongometa.collection
         index_info = DB.model_with_indexes.index_information()
         self.assertTrue(index_info['product_id_1_name_1']['unique'])
+
+        # Creating indexes on the child should not error.
+        ChildModel._mongometa.collection
+
+        # Index info should not have changed.
+        final_index_info = DB.model_with_indexes.index_information()
+        self.assertEqual(index_info, final_index_info)


### PR DESCRIPTION
Here's one solution to PYMODM-68: instead of creating the indexes when the class is created, we could create them when the model's collection is first used.  I think this is similar to what MongoEngine does.

Another option would be to give the user the option to disable automatic index creation, like MongoEngine's `auto_create_index=False`.