### PR TITLE
Mapfield mutable defaults

### DIFF
--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -117,7 +117,18 @@ class MongoBaseField(object):
 
     def is_undefined(self, inst):
         """Determine if a field is undefined (has not been given any value)."""
-        return self.attname not in inst._data
+        # If the field is in _data, then it's not undefined.
+        # This happens when you explicitly assign the field.
+        if self.attname in inst._data:
+            return False
+
+        # It's also possible to initialize a field by mutating its default value.
+        # When this happens, the field is in _defaults instead of _data,
+        # but the value in _defaults is different from the original default value.
+        if self.attname in inst._defaults and inst._defaults[self.attname] != self.get_default():
+            return False
+
+        return True
 
     @property
     def verbose_name(self):

--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -295,7 +295,7 @@ class MongoModelBase(object):
             for field in self._mongometa.get_fields():
                 if field.is_undefined(self):
                     continue
-                raw_value = self._data.get(field.attname)
+                raw_value = field.value_from_object(self)
                 if field.is_blank(raw_value):
                     son[field.mongo_name] = raw_value
                 else:

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -267,8 +267,11 @@ class FieldsTestCase(ODMTestCase):
         article = Article()
         self.assertIs(article.tags, article.tags)
 
-        article.tags.append('foo')
-        article.tags.append('bar')
+        tags = article.tags
+        tags.append('foo')
+        tags.append('bar')
+        self.assertFalse(Article.tags.is_undefined(article))
+        self.assertEqual(article.to_son()['tags'], ['foo', 'bar'])
         self.assertEqual(article.tags, ['foo', 'bar'])
 
         # Ensure tags is saved to the database.


### PR DESCRIPTION
I think we may have missed some cases in the `_defaults` PR (https://github.com/mongodb/pymodm/pull/33).  When you initialize a field by mutating the default value like this:
```
a = Article()
a.tags.append('foo')
```
then the field value `['foo']` is in `_defaults` but not `_data`.  So some operations like `is_undefined` and `to_son` think the field doesn't exist.  The tests didn't catch this because `clean_fields` would call `getattr(doc, field_name)`, which would cause the field to get copied into `_data` before the save.

In the University codebase we only observed this bug when using MapField, which is a custom PyMODM field we created.  I included that in a test to try to show that this bug can affect `.save()`, not just `.to_son()`.