### PR TITLE
Added 'note' to ListField docstring

### DIFF
--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -766,7 +766,10 @@ class ListField(MongoBaseField):
         :parameters:
           - `verbose_name`: A human-readable name for the Field.
           - `mongo_name`: The name of this field when stored in MongoDB.
-          - `field`: The Field type of all items in this list.
+          - `field`: The Field type of all items in this list. 
+
+        .. note:: 'field' needs to be an 'Field instance' and not a 
+                  'Field class'
 
         .. seealso:: constructor for
                      :class:`~pymodm.base.fields.MongoBaseField`

--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -766,10 +766,8 @@ class ListField(MongoBaseField):
         :parameters:
           - `verbose_name`: A human-readable name for the Field.
           - `mongo_name`: The name of this field when stored in MongoDB.
-          - `field`: The Field type of all items in this list. 
-
-        .. note:: 'field' needs to be an 'Field instance' and not a 
-                  'Field class'
+          - `field`: The Field type of all items in this list.
+            This needs to be an *instance* of a `MongoBaseField` subclass.
 
         .. seealso:: constructor for
                      :class:`~pymodm.base.fields.MongoBaseField`


### PR DESCRIPTION
I had posted this issue

https://jira.mongodb.org/browse/PYMODM-77

As stated there, it was not a bug - but a documentation 'gotcha'. 

This PR adds an explicit note to the docstring of ListField, thus making it clearer to future users. 