### PR TITLE
Update TravisCI to run with latest server versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ env:
     - MONGODB=3.0.14
     - MONGODB=3.2.12
     - MONGODB=3.4.3
-    - MONGODB=3.5.5
+    - MONGODB=3.6.6
+    - MONDODB=4.0.0
+    - MONDODB=4.1.1
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
     - MONGODB=3.2.20
     - MONGODB=3.4.16
     - MONGODB=3.6.6
-    - MONDODB=4.0.0
-    - MONDODB=4.1.1
+    - MONGODB=4.0.0
+    - MONGODB=4.1.1
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
 env:
   matrix:
     - MONGODB=2.6.12
-    - MONGODB=3.0.14
-    - MONGODB=3.2.12
-    - MONGODB=3.4.3
+    - MONGODB=3.0.15
+    - MONGODB=3.2.20
+    - MONGODB=3.4.16
     - MONGODB=3.6.6
     - MONDODB=4.0.0
     - MONDODB=4.1.1


### PR DESCRIPTION
Looks like the server versions against which CI is run on TravisCI has not been updated in a while. This PR updates the list to add all production ready server versions as well as the latest available development release of the server.