### PR TITLE
FIX: PYMODM-86

### DIFF
--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -88,6 +88,8 @@ class MongoBaseField(object):
                     self.attname, self.to_python)
             except KeyError:
                 value = self._get_default_once(inst)
+                if not self.is_blank(value):
+                    self.__set__(inst, value)
             return value
         return self
 

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -93,6 +93,20 @@ class Simple2(MongoModel):
 
 class FieldsTestCase(ODMTestCase):
 
+    def test_auto_generate_primary_key(self):
+        class AutoGeneratePrimaryKeyDefaultCallable(MongoModel):
+            identifier = fields.ObjectIdField(
+                primary_key=True, default=bson.ObjectId)
+            data = fields.CharField()
+        model = AutoGeneratePrimaryKeyDefaultCallable(data="some data")
+        model.save()
+
+    def test_commit_required_field_with_default(self):
+        class RequiredFieldWithDefault(MongoModel):
+            age = fields.IntegerField(default=10, required=True)
+        model = RequiredFieldWithDefault()
+        model.save()
+
     def test_field_encoding_decoding(self):
         def _refresh_and_reset(model_instance):
             model_instance.refresh_from_db()


### PR DESCRIPTION
[JIRA Issue](https://jira.mongodb.org/browse/PYMODM-86).

With this PR we now store non-empty defaults for all fields in the `LazyDecoder` instance attached to the `MongoModel`. This prevents failures on `save()` when trying to commit models with required fields containing default values. 