### PR TITLE
ENH: lazily initialize storage for FileField

### DIFF
--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -387,6 +387,10 @@ class FileField(MongoBaseField):
     def __get__(self, inst, owner):
         MongoModelBase = _import('pymodm.base.models.MongoModelBase')
         if inst is not None and isinstance(inst, MongoModelBase):
+            if self.storage is None:
+                gridfs = GridFSBucket(
+                    _get_db(self.model._mongometa.connection_alias))
+                self.storage = GridFSStorage(gridfs)
             try:
                 raw_value = inst._data.get_python_value(
                     self.attname, self.to_python)
@@ -401,12 +405,6 @@ class FileField(MongoBaseField):
             return self.to_python(_file)
         # Access from outside a Model instance.
         return self
-
-    def contribute_to_class(self, cls, name):
-        super(FileField, self).contribute_to_class(cls, name)
-        gridfs = GridFSBucket(_get_db(self.model._mongometa.connection_alias))
-        # Default GridFS storage.
-        self.storage = self.storage or GridFSStorage(gridfs)
 
 
 class ImageField(FileField):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -28,8 +28,6 @@ MONGO_URI = os.environ.get('MONGO_URI', 'mongodb://localhost:27017')
 CLIENT = pymongo.MongoClient(MONGO_URI)
 DB = CLIENT.odm_test
 
-connect('%s/%s' % (MONGO_URI, DB.name))
-
 # Get the version of MongoDB.
 server_info = pymongo.MongoClient(MONGO_URI).server_info()
 MONGO_VERSION = tuple(server_info.get('versionArray', []))
@@ -37,6 +35,16 @@ MONGO_VERSION = tuple(server_info.get('versionArray', []))
 
 INVALID_MONGO_NAMES = ['$dollar', 'has.dot', 'null\x00character']
 VALID_MONGO_NAMES = ['', 'dollar$', 'forty-two']
+
+
+def connect_to_test_DB(alias=None):
+    if alias is None:
+        connect('%s/%s' % (MONGO_URI, DB.name))
+    else:
+        connect('%s/%s' % (MONGO_URI, DB.name), alias=alias)
+
+
+connect_to_test_DB()
 
 
 class ODMTestCase(unittest.TestCase):


### PR DESCRIPTION
Implements lazy initialization for `FileField` instances. 

Closes [PYMODM-62](https://jira.mongodb.org/browse/PYMODM-62)