### PR TITLE
Fix: RecursionError raised when dereferencing models with circular references

### DIFF
--- a/pymodm/dereference.py
+++ b/pymodm/dereference.py
@@ -185,9 +185,6 @@ def dereference(model_instance, fields=None):
     # Map of collection name --> list of ids to retrieve from the collection.
     reference_map = defaultdict(list)
 
-    import ipdb as pdb
-    #pdb.set_trace()
-
     # Fields may be nested (dot-notation). Split each field into its parts.
     if fields:
         fields = [deque(field.split('.')) for field in fields]

--- a/test/test_dereference.py
+++ b/test/test_dereference.py
@@ -90,7 +90,7 @@ class DereferenceTestCase(ODMTestCase):
         # Test dereferencing only specific fields.
         # Contrived Models that contains more than one ReferenceField at
         # different levels of nesting.
-        class MultiReferenceModelEmbed(MongoModel):
+        class MultiReferenceModelEmbed(EmbeddedMongoModel):
             comments = fields.ListField(fields.ReferenceField(Comment))
             posts = fields.ListField(fields.ReferenceField(Post))
 

--- a/test/test_dereference.py
+++ b/test/test_dereference.py
@@ -297,13 +297,13 @@ class DereferenceTestCase(ODMTestCase):
             self.assertIsNone(comment.post)
 
     def test_dereference_circular_reference(self):
-        class Person(MongoModel):
+        class NewPerson(MongoModel):
             name = fields.CharField()
-            friends = fields.ListField(fields.ReferenceField('Person'))
-            emergency_contact = fields.ReferenceField('Person')
+            friends = fields.ListField(fields.ReferenceField('NewPerson'))
+            emergency_contact = fields.ReferenceField('NewPerson')
 
-        person1 = Person(name="Bob").save()
-        person2 = Person(name="Joe").save()
+        person1 = NewPerson(name="Bob").save()
+        person2 = NewPerson(name="Joe").save()
 
         person1.friends.append(person2)
         person1.emergency_contact = person2

--- a/test/test_dereference.py
+++ b/test/test_dereference.py
@@ -341,7 +341,13 @@ class DereferenceTestCase(ODMTestCase):
             comment.refresh_from_db()
             container.refresh_from_db()
 
+            # Test behavior on assignment to reference field.
+            container.ref = comment
+            self.assertEqual(container.ref.body, comment.body)
+            self.assertEqual(container.ref.post, comment.post)
+
             # Before dereferencing.
+            container.refresh_from_db()
             self.assertEqual(container.ref, comment.pk)
 
             # After dereferencing. This only dereferences fields on container.


### PR DESCRIPTION
# WIP

Closes [PYMODM-83](https://jira.mongodb.org/browse/PYMODM-83?filter=-1)

- [x] Fix test `test.test_dereference.DereferenceTestCase.test_dereference_fields`
