### PR TITLE
PYMODM-95 Validating EmbeddedMongoModel in EmbeddedDocument type fields

### DIFF
--- a/pymodm/base/fields.py
+++ b/pymodm/base/fields.py
@@ -267,6 +267,39 @@ class RelatedModelFieldsBase(MongoBaseField):
             '%s is not a valid %s' % (value, self.related_model.__name__))
 
 
+class RelatedEmbeddedModelFieldsBase(RelatedModelFieldsBase):
+    """Base class for EmbeddedDocument and EmbeddedDocumentListField."""
+
+    def __init__(self, model, verbose_name=None, mongo_name=None, **kwargs):
+        super(RelatedEmbeddedModelFieldsBase,
+              self).__init__(model=model,
+                             verbose_name=verbose_name,
+                             mongo_name=mongo_name,
+                             **kwargs)
+        self.__model = model
+        self.__related_model = None
+
+        EmbeddedMongoModel = _import('pymodm.base.models.EmbeddedMongoModel')
+        if not (isinstance(model, string_types) or
+                (isinstance(model, type) and
+                 issubclass(model, EmbeddedMongoModel))):
+            raise ValueError('model must be a EmbeddedMongoModel class or a '
+                             'string, not %s' % model)
+
+    @property
+    def related_model(self):
+        if not self.__related_model:
+            EmbeddedMongoModel = _import(
+                'pymodm.base.models.EmbeddedMongoModel')
+            if isinstance(self.__model, string_types):
+                self.__related_model = get_document(self.__model)
+            # 'issubclass' complains if first argument is not a class.
+            elif (isinstance(self.__model, type) and
+                  issubclass(self.__model, EmbeddedMongoModel)):
+                self.__related_model = self.__model
+        return self.__related_model
+
+
 class GeoJSONField(MongoBaseField):
     """Base class for GeoJSON fields."""
 

--- a/pymodm/fields.py
+++ b/pymodm/fields.py
@@ -48,7 +48,9 @@ except ImportError:
 
 
 from pymodm import validators
-from pymodm.base.fields import RelatedModelFieldsBase, GeoJSONField
+from pymodm.base.fields import (RelatedModelFieldsBase,
+                                GeoJSONField,
+                                RelatedEmbeddedModelFieldsBase)
 from pymodm.common import _import, validate_mongo_keys
 from pymodm.compat import text_type, string_types, PY3
 from pymodm.connection import _get_db
@@ -1054,7 +1056,7 @@ class GeometryCollectionField(MongoBaseField):
 # RelatedModelField types.
 #
 
-class EmbeddedDocumentField(RelatedModelFieldsBase):
+class EmbeddedDocumentField(RelatedEmbeddedModelFieldsBase):
     """A field that stores a document inside another document."""
 
     def __init__(self, model,
@@ -1091,7 +1093,7 @@ class EmbeddedDocumentField(RelatedModelFieldsBase):
         return self._model_to_document(value)
 
 
-class EmbeddedDocumentListField(RelatedModelFieldsBase):
+class EmbeddedDocumentListField(RelatedEmbeddedModelFieldsBase):
     """A field that stores a list of documents within a document.
 
     All documents in the list must be of the same type.

--- a/test/test_dereference.py
+++ b/test/test_dereference.py
@@ -91,7 +91,7 @@ class DereferenceTestCase(ODMTestCase):
 
         # Contrived Models that contains more than one ReferenceField at
         # different levels of nesting.
-        class MultiReferenceModelEmbed(MongoModel):
+        class MultiReferenceModelEmbed(EmbeddedMongoModel):
             comments = fields.ListField(fields.ReferenceField(Comment))
             posts = fields.ListField(fields.ReferenceField(Post))
 

--- a/test/test_related_fields.py
+++ b/test/test_related_fields.py
@@ -194,3 +194,22 @@ class RelatedFieldsTestCase(ODMTestCase):
         comment = Comment(body='this is a comment', post=post_id).save()
         comment.refresh_from_db()
         self.assertEqual('this is a post', comment.post.body)
+
+    def test_validate_embedded_model(self):
+        msg = 'model must be a EmbeddedMongoModel'
+
+        with self.assertRaisesRegex(ValueError, msg):
+            class Review(MongoModel):
+                text = fields.CharField()
+
+            class Blog(MongoModel):
+                name = fields.CharField()
+                reviews = fields.EmbeddedDocumentField(Review)
+
+        with self.assertRaisesRegex(ValueError, msg):
+            class Review(MongoModel):
+                text = fields.CharField()
+
+            class Blog(MongoModel):
+                name = fields.CharField()
+                reviews = fields.EmbeddedDocumentListField(Review)


### PR DESCRIPTION
Checked and validated type of related_field in EmbeddedDocumentField and EmbeddedDocumentListField. Raised Value error the same was as RelatedModelFieldsBase.