### PR TITLE
Fixes PYMODM-119

### DIFF
--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -290,6 +290,8 @@ class MongoModelBase(object):
     def to_son(self):
         """Get this Model back as a :class:`~bson.son.SON` object.
 
+        It does not dereference fields.
+
         :returns: SON representing this object as a MongoDB document.
 
         """


### PR DESCRIPTION
I created [PYMODM-119](https://jira.mongodb.org/projects/PYMODM/issues/PYMODM-119), expecting `to_son` to automatically dereference fields.

@ShaneHarvey explained why that cannot be, but agreed that this can be clarified in the docs.

Here is a one line addition to the docstring of `to_son`
```
It does not dereference fields.
```