### PR TITLE
PYMODM-131 Remove Python 3.3 tests from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - MONGODB=3.4.19
     - MONGODB=3.6.13
     - MONGODB=4.0.9
-    - MONGODB=4.1.11
+    - MONGODB=4.1.6
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - MONGODB=3.4.19
     - MONGODB=3.6.13
     - MONGODB=4.0.9
-    - MONGODB=4.1.6
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - MONGODB=3.4.19
     - MONGODB=3.6.13
     - MONGODB=4.0.9
-    - MONGODB=4.1.13
+    - MONGODB=4.1.11
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
 
 env:
   matrix:
     - MONGODB=2.6.12
     - MONGODB=3.0.15
-    - MONGODB=3.2.20
-    - MONGODB=3.4.16
-    - MONGODB=3.6.6
-    - MONGODB=4.0.0
-    - MONGODB=4.1.1
+    - MONGODB=3.2.22
+    - MONGODB=3.4.19
+    - MONGODB=3.6.13
+    - MONGODB=4.0.9
+    - MONGODB=4.2.0-rc2
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
 
 env:
   matrix:
@@ -14,7 +13,7 @@ env:
     - MONGODB=3.4.19
     - MONGODB=3.6.13
     - MONGODB=4.0.9
-    - MONGODB=4.2.0-rc2
+    - MONGODB=4.1.13
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
I also took the opportunity to update the server versions.