### PR TITLE
Fix: Aggregation add to queryset with sort

### DIFF
--- a/pymodm/queryset.py
+++ b/pymodm/queryset.py
@@ -14,6 +14,7 @@
 
 import copy
 
+from bson.son import SON
 import pymongo
 
 from pymodm import errors
@@ -166,7 +167,7 @@ class QuerySet(object):
         if self._projection:
             before_pipeline.append({'$project': self._projection})
         if self._order_by:
-            before_pipeline.append({'$sort': self._order_by})
+            before_pipeline.append({'$sort': SON(self._order_by)})
         if self._skip:
             before_pipeline.append({'$skip': self._skip})
         if self._limit:

--- a/test/test_queryset.py
+++ b/test/test_queryset.py
@@ -114,6 +114,12 @@ class QuerySetTestCase(ODMTestCase):
         assert_reverses(User.objects.order_by(
             [('_id', 1), ('phone', -1), ('lname', 1)]))
 
+    def test_order_by_with_aggregate(self):
+        results = list(User.objects.order_by([('_id', 1)]).aggregate(
+            {'$limit': 1}
+        ))
+        self.assertEqual('Amarth', results[0]['lname'])
+
     def test_project(self):
         results = User.objects.project({'lname': 1})
         for result in results:


### PR DESCRIPTION
Fix for `pymongo.errors.OperationFailure: the $sort key specification must be an object`. This occurs when a queryset has been given an `order_by` then an aggregation is added. `self._order_by` is a list of tuples, but must be an object. The order of keys in `order_by` matters, so we must use `SON`.