### PR TITLE
PYMODM-142 Using super() in MongoModel classes on Python 3.8+ should not result in RuntimeError

### DIFF
--- a/pymodm/base/models.py
+++ b/pymodm/base/models.py
@@ -42,8 +42,10 @@ class MongoModelMetaclass(type):
         if not model_parents:
             return type.__new__(mcls, name, bases, attrs)
 
-        new_class = type.__new__(
-            mcls, name, bases, {'__module__': attrs['__module__']})
+        new_attrs = {'__module__': attrs['__module__']}
+        if '__classcell__' in attrs:
+            new_attrs['__classcell__'] = attrs['__classcell__']
+        new_class = type.__new__(mcls, name, bases, new_attrs)
 
         # User-defined or inherited metadata
         meta = attrs.get('Meta', getattr(new_class, 'Meta', None))

--- a/test/test_model_inheritance.py
+++ b/test/test_model_inheritance.py
@@ -33,8 +33,11 @@ class MultipleInheritanceModel(User, AnotherUser):
 
 
 class FinalModel(MongoModel):
-    def __init__(self, *args, **kwargs):
-        super(FinalModel, self).__init__(*args, **kwargs)
+    def _set_attributes(self, dict):
+        """
+        To test proper functioning of super in Model classes with Python 3.8+ - see https://bugs.python.org/issue23722
+        """
+        return super(FinalModel, self)._set_attributes(dict)
 
     class Meta:
         final = True

--- a/test/test_model_inheritance.py
+++ b/test/test_model_inheritance.py
@@ -33,6 +33,9 @@ class MultipleInheritanceModel(User, AnotherUser):
 
 
 class FinalModel(MongoModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     class Meta:
         final = True
 

--- a/test/test_model_inheritance.py
+++ b/test/test_model_inheritance.py
@@ -34,7 +34,7 @@ class MultipleInheritanceModel(User, AnotherUser):
 
 class FinalModel(MongoModel):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(FinalModel, self).__init__(*args, **kwargs)
 
     class Meta:
         final = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # "pip install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35, py36, py37, pypy, pypy3
+envlist = py27, py33, py34, py35, py36, py37, py38, pypy, pypy3
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Fix error ```RuntimeError: __class__ not set defining ... Was __classcell__ propagated to type.__new__``` on Python 3.8, if super() is used in the models.